### PR TITLE
Fix firefox bootstrap loading

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake . --extra-deprecated-features url-literals

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,3 +1,4 @@
+require("bootstrap");
 const { Elm } = require('./Main.elm');
 
 const authUserIdKey = 'authUserId';


### PR DESCRIPTION
Problem: firefox didn't load bootstrap correctly
  and that result in a frequent frontend crashes

Solution: add explicit `require("bootstrap")` at the beginning of `index.js` file