### PR TITLE
[#14] Add email verification after registration

### DIFF
--- a/client/src/Api.elm
+++ b/client/src/Api.elm
@@ -52,6 +52,8 @@ type Endpoint
     | AdvancedSearchData
     | CustomerLogin Bool
     | CustomerRegister
+    | CustomerVerifyEmail String
+    | CustomerRequestVerification Int
     | CustomerAuthorize
     | CustomerLogout
     | CustomerResetRequest
@@ -150,6 +152,13 @@ toUrl endpoint =
 
                 CustomerRegister ->
                     joinPath [ "customers", "register" ]
+                
+                CustomerVerifyEmail uuid  ->
+                    joinPath [ "customers", "verify", uuid ]
+                
+                CustomerRequestVerification customerId ->
+                    joinPath [ "customers", "request-verification"]
+                        ++ withQueryStrings [queryParameter ( "customer", String.fromInt customerId)]
 
                 CustomerAuthorize ->
                     joinPath [ "customers", "authorize" ]

--- a/client/src/Auth/VerificationRequired.elm
+++ b/client/src/Auth/VerificationRequired.elm
@@ -1,0 +1,105 @@
+module Auth.VerificationRequired exposing
+  ( Msg,
+    Form,
+    initial,
+    update,
+    view
+  )
+
+import Api
+import Dict
+import Html exposing (..)
+import Html.Attributes exposing (class, disabled)
+import Html.Events exposing (onClick)
+import Ports
+import RemoteData exposing (WebData)
+import Routing exposing (Route(..))
+import Views.HorizontalForm as Form
+import Decode.Utils as Decode
+import Views.Utils exposing (icon)
+
+type alias Form =
+    { mailStatus : MailStatus
+    , errors : Api.FormErrors
+    }
+
+type MailStatus
+    = DidNotSendYet
+    | Sending
+    | MailWasSentSuccessfully
+    | AnErrorOccured
+
+initial : Form
+initial =
+    { mailStatus = DidNotSendYet
+    , errors = Api.initialErrors
+    }
+
+
+type Msg
+    = ResponseToVerificationRequest (WebData (Result Api.FormErrors ()))
+    | RequestVerification Int
+
+
+update : Msg -> Form -> (Form, Cmd Msg)
+update msg  form = case msg of
+  RequestVerification customerId ->
+      ( {form | mailStatus = Sending }
+      , Api.post (Api.CustomerRequestVerification customerId)
+          |> Api.withErrorHandler Decode.unit
+          |> Api.sendRequest ResponseToVerificationRequest
+      )
+  ResponseToVerificationRequest response ->
+    case response of
+      RemoteData.Success (Ok ()) ->
+          ( { form | mailStatus = MailWasSentSuccessfully }
+          , Cmd.batch
+              [ Ports.scrollToTop
+              ]
+          )
+      RemoteData.Success (Err errors) ->
+          ( { form | mailStatus = AnErrorOccured, errors = errors }
+          , Ports.scrollToErrorMessage
+          )
+
+      RemoteData.Failure error ->
+          ( { form | mailStatus = AnErrorOccured, errors = Api.apiFailureToError error }
+          , Ports.scrollToErrorMessage
+          )
+
+      _ ->
+          (form, Cmd.none)
+
+
+view : Int -> Form -> (Msg -> msg) -> List (Html msg)
+view customerId model tagger =
+    let
+        requestButton = case model.mailStatus of
+            DidNotSendYet ->
+                button [ class "btn btn-primary float-right ml-3",
+                          onClick (tagger (RequestVerification customerId)) ]
+                    [ text "Request a new email" ]
+            Sending ->
+                button [ class "btn btn-primary float-right ml-3", disabled True ]
+                    [ text "Sending...", icon "spinner fa-spin ml-2" ]
+            _ ->
+                text ""
+
+        andvertisementText = case model.mailStatus of
+            MailWasSentSuccessfully -> text "Success! Please, check your mailbox for a new verification email."
+            AnErrorOccured -> text "Something is wrong on our side, sorry..."
+            _ -> text "Unable to find your verification email? Check your spam folder or request a new one!"
+
+    in [ h1 [] [ text "Verify your email" ]
+    , hr [] []
+    , Form.genericErrorText (not <| Dict.isEmpty model.errors)
+    , Api.getErrorHtml "" model.errors
+    , p []
+        [ div [ class "p-3 mb-2 bg-warning text-dark" ]
+            [ text "You can't log into your account before you verify your email" ]
+        , div [ class "alert alert-info clearfix" ]
+              [ requestButton
+              , andvertisementText
+              ]
+        ]
+    ]

--- a/client/src/Auth/VerifyEmail.elm
+++ b/client/src/Auth/VerifyEmail.elm
@@ -1,0 +1,120 @@
+module Auth.VerifyEmail exposing
+  ( Form,
+    Msg,
+    verifyEmail,
+    initial,
+    update,
+    view
+  )
+
+
+import Api
+import Dict
+import Html exposing (..)
+import Html.Attributes exposing (class)
+import Html.Events exposing (onClick)
+import Ports
+import RemoteData exposing (WebData)
+import Routing exposing (Route(..))
+import Update.Utils exposing (nothingAndNoCommand)
+import User exposing (AuthStatus)
+import Views.HorizontalForm as Form
+import Json.Decode as Decode exposing (Decoder)
+
+type alias Form =
+    { status : FormStatus
+    , errors : Api.FormErrors
+    }
+
+type FormStatus = Waiting | Success | Expired
+
+initial : Form
+initial =
+    { status = Waiting
+    , errors = Api.initialErrors
+    }
+
+type Msg
+    = SuccessfulVerification (WebData (Result Api.FormErrors VerifyStatus))
+    | WaitingForResponse
+
+
+type VerifyStatus
+    = VerificationCompleted AuthStatus
+    | VerificationExpired
+
+verifyDecoder : Decoder VerifyStatus
+verifyDecoder =
+  Decode.field "status" Decode.string
+    |> Decode.andThen (\status ->
+      if status == "expired"
+        then Decode.succeed VerificationExpired
+        else Decode.map VerificationCompleted
+                (Decode.field "data" User.decoder))
+
+verifyEmail : String -> Cmd Msg
+verifyEmail uuid =
+  Api.post (Api.CustomerVerifyEmail uuid)
+        |> Api.withErrorHandler verifyDecoder
+        |> Api.sendRequest SuccessfulVerification
+
+
+update : Msg -> Form -> ( Form, Maybe AuthStatus, Cmd Msg )
+update msg form = case msg of
+  WaitingForResponse -> nothingAndNoCommand form
+  SuccessfulVerification response ->
+    case response of
+      RemoteData.Success (Ok (VerificationCompleted authStatus)) ->
+          ( { form | status = Success }
+          , Just authStatus
+          , Cmd.batch
+              [ Ports.scrollToTop
+              , User.storeDetails authStatus
+              ]
+          )
+      RemoteData.Success (Ok VerificationExpired) ->
+          ( { form | status = Expired }
+          , Nothing
+          , Cmd.none
+          )
+      RemoteData.Success (Err errors) ->
+          ( { form | errors = errors }
+          , Nothing
+          , Ports.scrollToErrorMessage
+          )
+
+      RemoteData.Failure error ->
+          ( { form | errors = Api.apiFailureToError error }
+          , Nothing
+          , Ports.scrollToErrorMessage
+          )
+
+      _ ->
+          form |> nothingAndNoCommand
+
+
+view : Form -> msg -> List (Html msg)
+view model logoutMsg =
+    [ h1 [] [ text "Verify an email" ]
+    , hr [] []
+    , Form.genericErrorText (not <| Dict.isEmpty model.errors)
+    , Api.getErrorHtml "" model.errors
+    , if Dict.isEmpty model.errors
+      then p []
+        [ text <| case model.status of
+            Waiting -> "Waiting for server responce..."
+            Success -> "Email was successfully verified!"
+            Expired -> "Your verification link already expired. Please, check your mailbox for a new one."
+        , if model.status == Success
+          then div [ class "alert alert-info clearfix" ]
+              [ button [ class "btn btn-primary float-right ml-3", onClick logoutMsg ]
+                  [ text "Log Out" ]
+              , text <|
+                  "You have been automatically logged into "
+                      ++ "your new account. If you are using a public computer, "
+                      ++ "please log out to keep your account details private."
+              ]
+          else text ""
+        ]
+      else text ""
+    ]

--- a/client/src/Cart.elm
+++ b/client/src/Cart.elm
@@ -10,7 +10,7 @@ module Cart exposing
 import Api
 import Dict exposing (Dict)
 import Html exposing (..)
-import Html.Attributes as A exposing (alt, class, colspan, disabled, src, step, type_, value)
+import Html.Attributes as A exposing (alt, class, colspan, disabled, src, type_, value)
 import Html.Events exposing (onClick, onSubmit)
 import Html.Extra exposing (viewIf)
 import Html.Keyed as Keyed
@@ -103,8 +103,8 @@ updateCart authStatus maybeCartToken { quantities } { items } =
 
         encodedQuantities =
             Encode.object <|
-                [ ( "quantities", Encode.object changed ) ]
-                    ++ encodedCartToken maybeCartToken
+                 ( "quantities", Encode.object changed ) 
+                    :: encodedCartToken maybeCartToken
     in
     if List.isEmpty changed then
         Cmd.none
@@ -123,12 +123,12 @@ removeItem authStatus maybeCartToken itemId =
     let
         encodedDelete =
             Encode.object <|
-                [ ( "quantities"
+                 ( "quantities"
                   , Encode.object
                         [ ( String.fromInt <| fromCartItemId itemId, Encode.int 0 ) ]
                   )
-                ]
-                    ++ encodedCartToken maybeCartToken
+                
+                    :: encodedCartToken maybeCartToken
     in
     case authStatus of
         User.Anonymous ->
@@ -265,8 +265,8 @@ view authStatus ({ quantities } as form_) ({ items, charges } as cartDetails) =
 
         tableFooter =
             tfoot [] <|
-                [ footerRow "font-weight-bold" "Sub-Total" totals.subTotal ]
-                    ++ List.map chargeRow charges.surcharges
+                 footerRow "font-weight-bold" "Sub-Total" totals.subTotal 
+                    :: List.map chargeRow charges.surcharges
                     ++ [ htmlOrBlank chargeRow <|
                             Maybe.map .charge charges.shippingMethod
                        , taxRow

--- a/client/src/Decode/Utils.elm
+++ b/client/src/Decode/Utils.elm
@@ -1,0 +1,9 @@
+module Decode.Utils exposing (..)
+
+import Json.Decode as Decode exposing (Decoder)
+
+
+unit : Decoder ()
+unit =
+  Decode.list (Decode.fail "excepted an empty list")
+    |> Decode.andThen (\_ -> Decode.succeed ())

--- a/client/src/Messages.elm
+++ b/client/src/Messages.elm
@@ -3,6 +3,8 @@ module Messages exposing (Msg(..))
 import AdvancedSearch
 import Api
 import Auth.CreateAccount as CreateAccount
+import Auth.VerifyEmail as VerifyEmail
+import Auth.VerificationRequired as VerificationRequired
 import Auth.EditAddress as EditAddress
 import Auth.EditLogin as EditLogin
 import Auth.Login as Login
@@ -64,7 +66,9 @@ type Msg
     | SearchMsg SiteSearch.Msg
     | AdvancedSearchMsg AdvancedSearch.Msg
     | CreateAccountMsg CreateAccount.Msg
+    | VerifyEmailMsg VerifyEmail.Msg
     | LoginMsg Login.Msg
+    | VerificationRequiredMsg VerificationRequired.Msg
     | ResetPasswordMsg ResetPassword.Msg
     | EditLoginMsg EditLogin.Msg
     | EditAddressMsg EditAddress.Msg

--- a/client/src/Model.elm
+++ b/client/src/Model.elm
@@ -5,6 +5,8 @@ module Model exposing
     )
 
 import Auth.CreateAccount as CreateAccount
+import Auth.VerifyEmail as VerifyEmail
+import Auth.VerificationRequired as VerificationRequired
 import Auth.EditAddress as EditAddress
 import Auth.EditLogin as EditLogin
 import Auth.Login as Login
@@ -44,6 +46,8 @@ type alias Model =
     , searchData : Search.Data
     , advancedSearchData : Search.Data
     , createAccountForm : CreateAccount.Form
+    , verifyEmailForm : VerifyEmail.Form
+    , verificationRequiredForm : VerificationRequired.Form
     , loginForm : Login.Form
     , editLoginForm : EditLogin.Form
     , editAddressForm : EditAddress.Form
@@ -99,6 +103,8 @@ initial key route =
     , searchData = Search.initial
     , advancedSearchData = Search.initial
     , createAccountForm = CreateAccount.initial
+    , verifyEmailForm = VerifyEmail.initial
+    , verificationRequiredForm = VerificationRequired.initial
     , loginForm = Login.initial
     , editLoginForm = EditLogin.initial
     , editAddressForm = EditAddress.initial

--- a/client/src/OrderDetails.elm
+++ b/client/src/OrderDetails.elm
@@ -203,6 +203,7 @@ orderTable ({ lineItems, products } as details) =
                 , td [ class "text-right" ] [ text <| Format.cents amount ]
                 ]
 
+        htmlOrBlank : ({ a | description : String, amount : Cents } -> Html msg) -> Maybe { a | description : String, amount : Cents } -> Html msg
         htmlOrBlank f maybe =
             case maybe of
                 Nothing ->

--- a/client/src/PageData.elm
+++ b/client/src/PageData.elm
@@ -940,6 +940,7 @@ type alias AdminEditCustomerData =
     , email : String
     , storeCredit : Cents
     , isAdmin : Bool
+    , verified : Bool
     , stripeId : Maybe String
     , avalaraCode : Maybe String
     , orders : List CustomerOrderData
@@ -948,11 +949,12 @@ type alias AdminEditCustomerData =
 
 adminEditCustomerDataDecoder : Decoder AdminEditCustomerData
 adminEditCustomerDataDecoder =
-    Decode.map7 AdminEditCustomerData
+    Decode.map8 AdminEditCustomerData
         (Decode.field "id" Decode.int)
         (Decode.field "email" Decode.string)
         (Decode.field "storeCredit" centsDecoder)
         (Decode.field "isAdmin" Decode.bool)
+        (Decode.field "verified" Decode.bool)
         (Decode.field "stripeId" <| Decode.nullable Decode.string)
         (Decode.field "avalaraCode" <| Decode.nullable Decode.string)
         (Decode.field "orders" <| Decode.list customerOrderDataDecoder)

--- a/client/src/SiteUI/Breadcrumbs.elm
+++ b/client/src/SiteUI/Breadcrumbs.elm
@@ -66,6 +66,12 @@ view route pageData =
 
                 CreateAccount ->
                     singleItem "Create an Account"
+                
+                VerifyEmail _ ->
+                    singleItem "Verify an email"
+                
+                VerificationRequired _ ->
+                    singleItem "Email verification required"
 
                 CreateAccountSuccess ->
                     [ inactiveItem "Create An Account" CreateAccount

--- a/client/src/View.elm
+++ b/client/src/View.elm
@@ -2,6 +2,8 @@ module View exposing (pageDescription, pageImage, pageTitle, view)
 
 import AdvancedSearch
 import Auth.CreateAccount as CreateAccount
+import Auth.VerifyEmail as VerifyEmail
+import Auth.VerificationRequired as VerificationRequired
 import Auth.EditAddress as EditAddress
 import Auth.EditLogin as EditLogin
 import Auth.Login as Login
@@ -49,7 +51,6 @@ import Views.ShippingAdmin as ShippingAdmin
 import Views.StaticPageAdmin as StaticPageAdmin
 import Views.SurchargesAdmin as SurchargesAdmin
 import Views.Utils exposing (pageOverlay, rawHtml)
-
 
 view : Model -> Document Msg
 view ({ route, pageData, navigationData, zone } as model) =
@@ -133,11 +134,17 @@ view ({ route, pageData, navigationData, zone } as model) =
                 CreateAccount ->
                     CreateAccount.view CreateAccountMsg model.createAccountForm
 
+                VerifyEmail _ ->
+                    VerifyEmail.view model.verifyEmailForm LogOut
+
                 CreateAccountSuccess ->
                     CreateAccount.successView
 
                 Login redirectTo clearCart ->
                     Login.view LoginMsg model.loginForm redirectTo clearCart
+                
+                VerificationRequired customerId ->
+                    VerificationRequired.view customerId model.verificationRequiredForm VerificationRequiredMsg
 
                 ResetPassword maybeCode ->
                     ResetPassword.view ResetPasswordMsg model.resetPasswordForm maybeCode
@@ -173,7 +180,7 @@ view ({ route, pageData, navigationData, zone } as model) =
 
                 CheckoutSuccess orderId newAccount ->
                     RemoteData.map2 Tuple.pair pageData.locations pageData.orderDetails
-                        |> withIntermediateText (apply <| Checkout.successView zone LogOut orderId newAccount)
+                        |> withIntermediateText (apply <| Checkout.successView zone orderId newAccount)
 
                 Admin Dashboard ->
                     withIntermediateText (AdminDashboard.view model.adminDashboard zone pageData.adminDashboard)
@@ -396,11 +403,17 @@ pageTitle ({ route, pageData } as model) =
         CreateAccount ->
             "Create an Account"
 
+        VerifyEmail _ ->
+            "Verify your email"
+
         CreateAccountSuccess ->
             "Account Creation Successful"
 
         Login _ _ ->
             "Customer Login"
+        
+        VerificationRequired _ ->
+            "Verification required"
 
         ResetPassword Nothing ->
             "Reset Password"
@@ -587,6 +600,12 @@ pageDescription { route, pageData } =
 
         CreateAccount ->
             "Create a free account to purchase products from our catalog."
+
+        VerifyEmail _ ->
+            "Verify email to continue shopping"
+        
+        VerificationRequired _ ->
+            "Verification required before you're able to login"
 
         ResetPassword _ ->
             "Reset the password to your Southern Exposure Seed Exchange account."

--- a/client/src/Views/CustomerAdmin.elm
+++ b/client/src/Views/CustomerAdmin.elm
@@ -379,6 +379,9 @@ edit zone model locations original =
             InputIsAdmin
             "Is Administrator"
             "IsAdmin"
+        , div [ class "form-group form-row align-items-center" ] 
+              [ div [ class "col-sm-3 col-form-label" ] []
+              , text <| if original.verified then "This user is verified" else "This user is not verified" ]
         , deleteWarningText
         , div [ class "form-group d-flex justify-content-between" ]
             [ Admin.submitOrSavingButton model "Update Customer"

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -71,6 +71,7 @@ dependencies:
     - markdown
     - mime-mail
     - mtl
+    - network
     - pandoc
     - persistent
     - persistent-template

--- a/server/src/Emails/VerifyEmail.hs
+++ b/server/src/Emails/VerifyEmail.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Emails.VerifyEmail (get) where
+
+
+import qualified Data.Text.Lazy as L
+
+
+get :: L.Text -> L.Text -> (String, L.Text)
+get domainName verificationCode =
+    ( "Southern Exposure Seed Exchange - Email Verification"
+    , renderVerification domainName verificationCode
+    )
+
+renderVerification :: L.Text -> L.Text -> L.Text
+renderVerification domainName verificationId =
+    "Hello,\n\n" <>
+    "Thank you for registering with [Southern Exposure][1]. To complete your registration, " <>
+    "please verify your email address by clicking [this link to verify your email][2].\n\n" <>
+    "If you did not create an account, you can safely ignore this email. The verification link " <>
+    "will expire in 24 hours.\n\n" <>
+    "Thank You,\n\nSouthern Exposure Seed Exchange\n\n"
+        <> "[1]: http://www.southernexposure.com/\n"
+        <> "[2]: " <> domainName <> "/account/verify/" <> verificationId <> "\n"
+

--- a/server/src/Models/DB.hs
+++ b/server/src/Models/DB.hs
@@ -99,9 +99,17 @@ Customer
     stripeId StripeCustomerId Maybe
     avalaraCode AvalaraCustomerCode Maybe
     isAdmin Bool default=false
+    verified Bool default=true
     UniqueToken authToken
     UniqueAvalaraCustomer avalaraCode !force
     UniqueEmail email
+
+Verification
+    code T.Text
+    customerId CustomerId OnDeleteCascade
+    createdAt UTCTime
+    UniqueVerificationCode code
+    UniqueCustomerToVerify customerId
 
 PasswordReset
     customerId CustomerId

--- a/server/src/Routes/EmailVerification.hs
+++ b/server/src/Routes/EmailVerification.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Routes.EmailVerification
+  ( newEmailVerification
+  ) where
+
+import Control.Monad (join)
+import Control.Monad.IO.Class (liftIO)
+import Data.Time.Clock (getCurrentTime)
+import Database.Persist
+    ( Entity(..), getBy, insertUnique
+    )
+import Servant
+    ( err500
+    )
+
+import Models
+import Routes.Utils (generateUniqueToken)
+import Server
+import Workers (Task(..), enqueueTask)
+
+import qualified Database.Esqueleto.Experimental as E
+import qualified Emails
+import Data.Foldable (for_)
+
+newEmailVerification :: CustomerId -> App ()
+newEmailVerification customerId = join $ runDB $ do
+    mOldVer <- fmap entityKey <$> getBy (UniqueCustomerToVerify customerId)
+    for_ mOldVer $ \verId -> E.delete $ do
+        ver <- E.from $ E.table @Verification
+        E.where_ (ver E.^. VerificationId E.==. E.val verId)
+    verificationCreatedAt <- liftIO getCurrentTime
+    verificationCode <- generateUniqueToken UniqueVerificationCode
+    let verification = Verification
+            { verificationCustomerId = customerId, ..
+            }
+    mVer <- insertUnique verification
+    case mVer of
+        Nothing -> pure (serverError err500)
+        Just verId -> do
+            enqueueTask Nothing (SendEmail $ Emails.EmailVerification customerId verId)
+            pure (pure ())

--- a/server/src/Workers.hs
+++ b/server/src/Workers.hs
@@ -210,6 +210,8 @@ taskQueueConfig threadCount cfg@Config { getPool, getServerLogger, getCaches } =
                 "Customer #" <> showSqlKey cId <> " Requested Password Reset Email"
             Emails.PasswordResetSuccess cId ->
                 "Customer #" <> showSqlKey cId <> " Password Reset Succeeded Email"
+            Emails.EmailVerification cId _ ->
+                "Customer #" <> showSqlKey cId <> " Email Verification Email"
             Emails.OrderPlaced oId ->
                 "Order #" <> showSqlKey oId <> " Placed Email"
         CleanDatabase ->


### PR DESCRIPTION
Problem: We don't check if an email submitted by a person is real or not. That prevent us from making anonymous checkouts, because everyone may create an account with an arbitrary email address

Solution: send a confirmation email when a user want to register; do not allow them to log in before they verify their email account. Suggest them to resend a confirmation email when they attempt to log in.