### PR TITLE
Unwire base url hardcoding

### DIFF
--- a/server/src/Config.hs
+++ b/server/src/Config.hs
@@ -57,6 +57,7 @@ data Config
     , getStripeLogger :: TimedFastLogger
     , getServerLogger :: TimedFastLogger
     , getDeveloperEmail :: Maybe Text
+    , getBaseUrl :: Text
     }
 
 defaultConfig :: Config
@@ -82,6 +83,7 @@ defaultConfig =
         , getStripeLogger = undefined
         , getServerLogger = undefined
         , getDeveloperEmail = Nothing
+        , getBaseUrl = "http://localhost:7000"
         }
 
 timedLogStr :: ToLogStr a => a -> FormattedTime -> LogStr

--- a/server/src/Emails.hs
+++ b/server/src/Emails.hs
@@ -127,16 +127,7 @@ send cfg email =
                 _ ->
                     []
 
-
-        -- TODO: Make this configurable - real domain is needed in several
-        -- places(here & Feeds)
-        domainName =
-            case getEnv cfg of
-                Development ->
-                    "http://localhost:7000"
-                Production ->
-                    "https://www.southernexposure.com"
-
+        domainName = L.fromStrict $ getBaseUrl cfg
 
         (subject, message) =
             case email of
@@ -150,7 +141,7 @@ send cfg email =
                 OrderPlacedData parameters ->
                     OrderPlaced.get parameters
                 EmailVerificationData _ vCode ->
-                    EmailVerification.get domainName (L.fromStrict vCode) 
+                    EmailVerification.get domainName (L.fromStrict vCode)
 
         (plainMessage, htmlMessage) =
             case email of


### PR DESCRIPTION
Problem: there's base url hardcoding in several places
  so we can't host server on an arbitrary url

Solution: read base url at the startup and look at the config
  each time we want to know our base url