### PR TITLE
Install ca-certiticates in backend image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ COPY client/nginx/nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 8080
 
 FROM debian:bookworm-slim AS backend
-RUN apt-get -y update && apt-get install -y libpq5
+RUN apt-get -y update && apt-get install -y libpq5 ca-certificates
 RUN useradd -m -U -d /home/sese -s /bin/bash sese
 COPY --from=backend-builder /root/.local/bin/sese-website-exe /usr/local/bin/sese-website-exe
 COPY server/scripts/entrypoint.sh /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
Otherwise, the backend cannot query remote integrations (such as Avalara or Helcim) due to an unknown certificate authority.