### PR TITLE
Replace OverflowNatural with Int64

### DIFF
--- a/server/scripts/ExportOddWeights.hs
+++ b/server/scripts/ExportOddWeights.hs
@@ -107,7 +107,7 @@ getMass :: Entity ProductVariant -> Natural
 getMass v =
     case productVariantLotSize (entityVal v) of
         Just (Mass (Milligrams m)) ->
-            m
+            fromIntegral m
         _ ->
             0
 

--- a/server/src/Cache.hs
+++ b/server/src/Cache.hs
@@ -28,7 +28,7 @@ import Database.Persist ((>=.), (<.), (<-.), Entity(..), selectList)
 import Database.Persist.Sql (SqlPersistT)
 
 import Models.DB
-import Models.Fields (Cents(..), mkCents, creditLineItemTypes)
+import Models.Fields (Cents(..), creditLineItemTypes, timesQuantity, sumPrices)
 
 import qualified Data.Map.Strict as M
 
@@ -172,10 +172,10 @@ getTotalForTimePeriod startTime endTime = do
     return $ SalesData startTime total
   where
     getOrderTotal items products = Cents . fromIntegral $
-        integerCents (sum $ map productTotal products) + sum (map lineTotal items)
+        integerCents (sumPrices $ map productTotal products) + sum (map lineTotal items)
     productTotal :: Entity OrderProduct -> Cents
     productTotal (Entity _ p) =
-        mkCents (orderProductQuantity p) * orderProductPrice p
+        orderProductPrice p `timesQuantity` orderProductQuantity p
     lineTotal :: Entity OrderLineItem -> Integer
     lineTotal (Entity _ l) =
         let amount = integerCents $ orderLineItemAmount l

--- a/server/src/Models/DB.hs
+++ b/server/src/Models/DB.hs
@@ -18,7 +18,7 @@ module Models.DB where
 import Control.Monad.IO.Class (MonadIO)
 import Data.Int (Int64)
 import Data.Time.Clock (UTCTime)
-import Database.Persist.Sql (SqlPersistT, Entity(..), OverflowNatural, selectList, insertEntity, delete, replace)
+import Database.Persist.Sql (SqlPersistT, Entity(..), selectList, insertEntity, delete, replace)
 import Database.Persist.TH
 
 import Models.Fields
@@ -141,7 +141,7 @@ Cart
 CartItem
     cartId CartId
     productVariantId ProductVariantId
-    quantity OverflowNatural
+    quantity Int64
     UniqueCartItem cartId productVariantId
 
 
@@ -161,7 +161,7 @@ ShippingMethod
     categoryIds [CategoryId]
     excludedPriorityCategoryIds [CategoryId]
     isActive Bool
-    priority OverflowNatural
+    priority Int64
     isPriorityEnabled Bool default=True
 
 
@@ -173,8 +173,8 @@ Coupon
     discount CouponType
     minimumOrder Cents
     expirationDate UTCTime
-    totalUses OverflowNatural
-    usesPerCustomer OverflowNatural
+    totalUses Int64
+    usesPerCustomer Int64
     createdAt UTCTime
     UniqueCoupon code
     deriving Show
@@ -228,7 +228,7 @@ OrderLineItem json
 OrderProduct
     orderId OrderId
     productVariantId ProductVariantId
-    quantity OverflowNatural
+    quantity Int64
     price Cents
     UniqueOrderProduct orderId productVariantId
     deriving Show

--- a/server/src/Models/Utils.hs
+++ b/server/src/Models/Utils.hs
@@ -273,13 +273,13 @@ applyVATax preTaxTotal =
 
 -- | Calculate the total tax from all of an Order's Products.
 getOrderTax :: [OrderLineItem] -> Cents
-getOrderTax = sum . map orderLineItemAmount . filter ((==) TaxLine . orderLineItemType)
+getOrderTax = sumPrices . map orderLineItemAmount . filter ((==) TaxLine . orderLineItemType)
 
 -- | Calculate the total price from all of an Order's Products.
 getOrderSubtotal :: [OrderProduct] -> Cents
-getOrderSubtotal = sum . map
+getOrderSubtotal = sumPrices . map
     (\prod ->
-        orderProductPrice prod * mkCents (orderProductQuantity prod)
+        orderProductPrice prod `timesQuantity` orderProductQuantity prod
     )
 
 -- | Calculate the sum of all OrderLineItem charge's for an Order.

--- a/server/src/Routes/Admin/Coupons.hs
+++ b/server/src/Routes/Admin/Coupons.hs
@@ -18,7 +18,6 @@ import Data.Time
     )
 import Database.Persist
     ( Entity(..), SelectOpt(Desc), Update, selectList, insert, get, update
-    , OverflowNatural(..)
     )
 import Numeric.Natural (Natural)
 import Servant
@@ -32,7 +31,6 @@ import Models.Fields (Cents, CouponType(..))
 import Server (App, runDB, serverError)
 import Routes.Utils (mapUpdate, parseLocalTime, parseMaybeLocalTime)
 import Validation (Validation(..))
-import Data.Coerce(coerce)
 
 import qualified Data.Text as T
 import qualified Validation as V
@@ -171,8 +169,8 @@ newCouponRoute = validateAdminAndParameters $ \_ NewCouponParameters {..} -> do
         , couponDiscount = ncpDiscount
         , couponMinimumOrder = ncpMinimumOrder
         , couponExpirationDate = expiration
-        , couponTotalUses = OverflowNatural ncpTotalUses
-        , couponUsesPerCustomer = OverflowNatural ncpUsesPerCustomer
+        , couponTotalUses = fromIntegral ncpTotalUses
+        , couponUsesPerCustomer = fromIntegral ncpUsesPerCustomer
         , couponCreatedAt = currentTime
         }
 
@@ -230,8 +228,8 @@ editCouponDataRoute t couponId = withAdminCookie t $ \_ ->
                 , ecdDiscount = couponDiscount
                 , ecdMinimumOrder = couponMinimumOrder
                 , ecdExpirationDate = localDay localTime
-                , ecdTotalUses = unOverflowNatural couponTotalUses
-                , ecdUsesPerCustomer = unOverflowNatural couponUsesPerCustomer
+                , ecdTotalUses = fromIntegral couponTotalUses
+                , ecdUsesPerCustomer = fromIntegral couponUsesPerCustomer
                 }
 
 
@@ -311,6 +309,6 @@ editCouponRoute = validateAdminAndParameters $ \_ parameters -> do
             , mapUpdate CouponDiscount ecpDiscount
             , mapUpdate CouponMinimumOrder ecpMinimumOrder
             , mapUpdate CouponExpirationDate expires
-            , mapUpdate CouponTotalUses (coerce ecpTotalUses)
-            , mapUpdate CouponUsesPerCustomer (coerce ecpUsesPerCustomer)
+            , mapUpdate CouponTotalUses (fmap fromIntegral ecpTotalUses)
+            , mapUpdate CouponUsesPerCustomer (fmap fromIntegral ecpUsesPerCustomer)
             ]

--- a/server/src/Routes/Admin/Customers.hs
+++ b/server/src/Routes/Admin/Customers.hs
@@ -31,7 +31,7 @@ import Models
     ( CustomerId, Customer(..), Address(..), EntityField(..), Unique(..)
     , Order(..), OrderId, getOrderTotal, AddressId
     )
-import Models.Fields (Cents, StripeCustomerId, OrderStatus, AvalaraCustomerCode)
+import Models.Fields (Cents, StripeCustomerId, OrderStatus, AvalaraCustomerCode, mkCents)
 import Routes.CommonData (AddressData, toAddressData)
 import Routes.Utils (extractRowCount, buildWhereQuery, hashPassword, generateUniqueToken, mapUpdate)
 import Server (App, AppSQL, runDB, serverError)
@@ -388,7 +388,7 @@ customerDeleteRoute t customerId = withAdminCookie t $ \_ -> runDB $ do
             token <- generateUniqueToken UniqueToken
             insert Customer
                 { customerEmail = "gardens+deleted@southernexposure.com"
-                , customerStoreCredit = 0
+                , customerStoreCredit = mkCents 0
                 , customerMemberNumber = ""
                 , customerEncryptedPassword = Just hashedPassword
                 , customerAuthToken = token

--- a/server/src/Routes/Customers.hs
+++ b/server/src/Routes/Customers.hs
@@ -61,6 +61,7 @@ import qualified Models.Fields as Fields
 import qualified Validation as V
 import Routes.EmailVerification
 import Control.Monad.Identity
+import Data.Coerce
 
 
 type CustomerAPI =
@@ -584,7 +585,7 @@ myAccountRoute token maybeLimit = withValidatedCookie token $ \(Entity customerI
             let
                 productQuantity =
                     orderProduct E.^. OrderProductQuantity
-                productPrice =
+                productPrice = coerce @_ @(E.SqlExpr (E.Value Int64)) $
                     orderProduct E.^. OrderProductPrice
                 subTotal =
                     sum0_ $ E.castNum productQuantity E.*. productPrice


### PR DESCRIPTION
Problem: during initial update we replaced
  deprecated `Natural` database instances with
  `OverflowNatural`, but this newtype is inconvenient
  and exposes deprecated behavior

Solution: replace it with Int64, update all the backend
  accordingly