### PR TITLE
[#9] Support order status updates from Stone Edge

### DIFF
--- a/client/src/Auth/MyAccount.elm
+++ b/client/src/Auth/MyAccount.elm
@@ -83,7 +83,7 @@ orderTable zone locations orderSummaries =
                 [ td [ class "text-center" ] [ text <| Format.date zone created ]
                 , td [ class "text-center" ] [ text <| String.fromInt id ]
                 , td [] [ addressInfo shippingAddress ]
-                , td [ class "text-center" ] [ text <| PageData.statusText status ]
+                , td [ class "text-center" ] [ text <| status ]
                 , td [ class "text-right" ] [ text <| Format.cents total ]
                 , td [ class "text-center" ]
                     [ a
@@ -103,7 +103,7 @@ orderTable zone locations orderSummaries =
                 , h5 [ class "mb-1" ] [ text "Ship To:" ]
                 , addressInfo shippingAddress
                 , div [ class "d-flex font-weight-bold mb-1" ]
-                    [ div [] [ text <| PageData.statusText status ]
+                    [ div [] [ text <| status ]
                     , div [ class "ml-auto" ] [ text <| Format.cents total ]
                     ]
                 , a (class "mb-1 btn btn-light btn-block" :: routeLinkAttributes (OrderDetails id Nothing))

--- a/client/src/OrderDetails.elm
+++ b/client/src/OrderDetails.elm
@@ -22,6 +22,7 @@ view zone orderId locations orderDetails =
         , small [] [ text <| " " ++ Format.date zone orderDetails.order.createdAt ]
         ]
     , hr [] []
+    , h2 [] [text <| "Status: " ++ orderDetails.order.status ]
     , div [ class "row mb-3" ] <|
         case orderDetails.billingAddress of
             Nothing ->
@@ -35,6 +36,14 @@ view zone orderId locations orderDetails =
                 , div [ class "col-sm-6" ]
                     [ addressCard locations "Billing Details" billingAddress ]
                 ]
+    , if orderDetails.deliveryData == [] then
+        text ""
+      else
+        div [ class "row mb-3" ] [
+            div [ class "col-12" ]
+                [ deliveryCard orderDetails.deliveryData 
+                ]
+        ]
     , orderTable orderDetails
     ]
 
@@ -48,6 +57,25 @@ addressCard locations titleText address =
             ]
         ]
 
+deliveryCard : List(PageData.DeliveryData) -> Html msg
+deliveryCard deliveryData =
+    div [ class "card h-100" ]
+        [ div [ class "card-body" ]
+            [ h4 [ class "card-title" ] [ text "Delivery" ]
+            , ul []
+                (List.map (\d ->
+                    (li []
+                        [ text <| "Carrier: " ++ d.trackCarrier
+                        , br [] []
+                        , text <| "Tracking Number: " ++ d.trackNumber
+                        , br [] []
+                        , text <| "Pickup Date: " ++ d.trackPickupDate
+                        ])
+                    )
+                    deliveryData
+                )
+            ]
+        ]
 
 type Tuple8 a b c d e f g h
     = Tuple8 a b c d e f g h

--- a/client/src/Views/CustomerAdmin.elm
+++ b/client/src/Views/CustomerAdmin.elm
@@ -22,7 +22,7 @@ import Json.Decode as Decode
 import Json.Encode as Encode
 import Locations exposing (AddressLocations)
 import Models.Fields exposing (Cents(..), centsFromString)
-import PageData exposing (CustomerData, statusText)
+import PageData exposing (CustomerData)
 import Paginate exposing (Paginated)
 import RemoteData exposing (WebData)
 import Routing exposing (AdminRoute(..), Route(..))
@@ -308,7 +308,7 @@ edit zone helcimUrl model locations original =
             tr []
                 [ td [] [ text <| String.fromInt order.id ]
                 , td [] [ text <| Format.date zone order.date ]
-                , td [] [ text <| statusText order.status ]
+                , td [] [ text <| order.status ]
                 , td [] [ Address.card order.shipping locations ]
                 , td [] [ text <| Format.cents order.total ]
                 , td [] [ a (routeLinkAttributes <| Admin <| AdminOrderDetails order.id) [ text "View Order" ] ]

--- a/client/src/Views/OrderAdmin.elm
+++ b/client/src/Views/OrderAdmin.elm
@@ -100,7 +100,7 @@ list zone locations currentQuery { query } orders =
                 , td [] [ text order.email ]
                 , td [] [ text order.street ]
                 , td [] [ text <| Maybe.withDefault "" <| Locations.regionName locations order.state ]
-                , td [] [ text <| PageData.statusText order.status ]
+                , td [] [ text <| order.status ]
                 , td [] [ text <| Format.cents order.total ]
                 , td []
                     [ a (routeLinkAttributes <| Admin <| AdminOrderDetails order.id)

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -253,6 +253,10 @@ module.exports = {
         changeOrigin: true,
       }
     },
+    https: {
+      key: '../local.southernexposure.com+2-key.pem',
+      cert: '../local.southernexposure.com+2.pem',
+    }
   },
 
 }

--- a/server/src/Emails/OrderStatusUpdated.hs
+++ b/server/src/Emails/OrderStatusUpdated.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+module Emails.OrderStatusUpdated (Parameters(..), fetchData, get) where
+
+import Control.Monad.Cont (MonadIO)
+import Data.Bool (bool)
+import qualified Database.Esqueleto.Experimental as E
+import qualified Data.Text.Lazy as L
+
+import Models.DB
+    (Customer(..), Key(..), EntityField (OrderDeliveryId), Order(..), OrderDelivery(..), OrderDeliveryId, OrderId)
+import Database.Persist (selectList, (<-.))
+import Routes.CommonData (toOrderStatus)
+
+data Parameters = Parameters
+    { order :: E.Entity Order
+    , customer :: Customer
+    , trackData :: [OrderDelivery]
+    }
+
+
+showOrderId :: E.Entity Order -> String
+showOrderId (E.Entity orderId _) = show $ E.unSqlBackendKey $ unOrderKey orderId
+
+get :: L.Text -> Parameters -> (String, L.Text)
+get domainName parameters =
+    ( "Southern Exposure Seed Exchange - Order #" <> showOrderId (order parameters) <> " Status Update"
+    , render domainName parameters
+    )
+
+renderOrderDelivery :: OrderDelivery -> L.Text
+renderOrderDelivery (OrderDelivery _ trackNum carrier pickupDate) =
+    "* Tracking number: " <> L.fromStrict trackNum <> " | Carrier: " <> L.fromStrict carrier <> " | Pickup date: " <> L.fromStrict pickupDate
+
+render :: L.Text -> Parameters -> L.Text
+render domainName Parameters {..} =
+    "Hello,\n\n" <>
+    "Order #" <> L.pack (showOrderId order) <> " has been updated.\n\n" <>
+    "Order status is: " <> L.fromStrict (toOrderStatus (E.entityVal order)) <> ".\n\n" <>
+    bool ("New delivery tracking data:\n\n" <> L.unlines (map renderOrderDelivery trackData) <> "\n\n") "" (null trackData) <>
+    "[View order status](" <> orderLink <> ")\n\n" <>
+
+    "Best regards,\n" <>
+    "Southern Exposure Seed Exchange"
+    where
+        orderLink =
+            domainName <>
+            "/account/order/" <> L.pack (showOrderId order) <>
+            maybe "" (\token -> L.fromStrict "?token=" <> L.fromStrict token) (orderGuestToken $ E.entityVal order)
+
+fetchData :: (Monad m, MonadIO m) => OrderId -> [OrderDeliveryId] -> E.SqlPersistT m (Maybe Parameters)
+fetchData orderId orderDeliveryIds = do
+    orderEntity <- E.get orderId
+    case orderEntity of
+        Nothing -> return Nothing
+        Just order -> do
+            trackData <- map E.entityVal <$> selectList [ OrderDeliveryId <-. orderDeliveryIds ] []
+            customerEntity <- E.get (orderCustomerId order)
+            case customerEntity of
+                Nothing -> return Nothing
+                Just customer -> return $ Just Parameters { order = E.Entity orderId order, customer = customer, trackData = trackData }

--- a/server/src/Models/DB.hs
+++ b/server/src/Models/DB.hs
@@ -202,6 +202,7 @@ Order
     customerId CustomerId
     guestToken T.Text Maybe
     status OrderStatus
+    stoneEdgeStatus T.Text Maybe
     billingAddressId AddressId Maybe
     shippingAddressId AddressId
     customerComment T.Text
@@ -233,6 +234,13 @@ OrderProduct
     UniqueOrderProduct orderId productVariantId
     deriving Show
 
+OrderDelivery
+    orderId OrderId
+    trackNumber T.Text
+    trackCarrier T.Text
+    trackPickupDate T.Text
+    UniqueOrderDelivery orderId trackNumber trackCarrier
+    deriving Show
 
 ProductSale
     price Cents

--- a/server/src/Models/Fields.hs
+++ b/server/src/Models/Fields.hs
@@ -523,6 +523,15 @@ data OrderStatus
     | Delivered
     deriving (Show, Read, Generic)
 
+showOrderStatus :: OrderStatus -> T.Text
+showOrderStatus = \case
+    OrderReceived -> "Order Received"
+    PaymentReceived -> "Payment Received"
+    PaymentFailed -> "Payment Failed"
+    Processing -> "Processing"
+    Refunded -> "Refunded"
+    Delivered -> "Shipped"
+
 instance ToJSON OrderStatus
 instance FromJSON OrderStatus
 

--- a/server/src/Routes/Checkout.hs
+++ b/server/src/Routes/Checkout.hs
@@ -53,7 +53,7 @@ import Routes.CommonData
     ( CartItemData(..), CartCharges(..)
     , CartCharge(..), getCartItems, getCharges, AddressData(..), toAddressData
     , fromAddressData, ShippingCharge(..), VariantData(..), getVariantPrice
-    , OrderDetails(..), toCheckoutOrder, getCheckoutProducts, CheckoutProduct
+    , OrderDetails(..), toCheckoutOrder, getCheckoutProducts, CheckoutProduct, toDeliveryData
 
     , BaseProductData(..)
     )
@@ -1075,6 +1075,7 @@ createOrder ce@(Entity customerId customer) cartId shippingEntity
     let order = Order
             { orderCustomerId = customerId
             , orderStatus = OrderReceived
+            , orderStoneEdgeStatus = Nothing
             , orderBillingAddressId = billingId
             , orderShippingAddressId = entityKey shippingEntity
             , orderGuestToken = maybeGuestToken
@@ -1282,12 +1283,14 @@ getOrderDetails externalOrderId customerId = do
         lineItems <-
             selectList [OrderLineItemOrderId ==. orderId] []
         products <- getCheckoutProducts orderId
+        delivery <- selectList [OrderDeliveryOrderId ==. orderId] []
         return OrderDetails
             { odOrder = toCheckoutOrder e
             , odLineItems = lineItems
             , odProducts = products
             , odShippingAddress = toAddressData shipping
             , odBillingAddress = toAddressData <$> billing
+            , odDeliveryData = toDeliveryData <$> delivery
             }
 data AnonymousSuccessParameters = MkAnonymousSuccessParameters
     { aspOrderId :: Int64

--- a/server/src/Workers.hs
+++ b/server/src/Workers.hs
@@ -214,6 +214,8 @@ taskQueueConfig threadCount cfg@Config { getPool, getServerLogger, getCaches } =
                 "Customer #" <> showSqlKey cId <> " Email Verification Email"
             Emails.OrderPlaced oId ->
                 "Order #" <> showSqlKey oId <> " Placed Email"
+            Emails.OrderStatusUpdated oId _ ->
+                "Order #" <> showSqlKey oId <> " Status Updated Email"
         CleanDatabase ->
             "Clean Database"
         Avalara (RefundTransaction code type_ amount) ->


### PR DESCRIPTION
* 'updatestatus' SETI function is now supported.

  This function updates 'stoneEdgeStatus' field for the order with given number.

  Additionally, it handles optionally provided delivery tracking data and puts it into 'OrderDelivery' table.

* The frontend now displays an order status the following way: if 'stoneEdgeStatus' is present, it is shown to the user, alternatively, the existing 'status' is shown to the user. In addition, to the status, order details now contain the information about order delivery (if such data is available for the given order).

* Whenever the order status is updated, a message is sent to the customer email with the status update and delivery tracking details.