### PR TITLE
[Chore] Return Customer ID from website via 'WebCustomerId'

### DIFF
--- a/server/src/StoneEdge.hs
+++ b/server/src/StoneEdge.hs
@@ -600,7 +600,7 @@ renderStoneEdgeOtherData StoneEdgeOtherData {..} =
     xelem "Other" $ xelems
         [ maybeXelemText "OrderInstructions" seodOrderInstructions
         , maybeXelemText "Comments" seodComments
-        , maybeXelemTextWith "CustomerID" showText seodCustomerId
+        , maybeXelemTextWith "WebCustomerID" showText seodCustomerId
         ]
 
 

--- a/server/test/StoneEdgeFixtures.hs
+++ b/server/test/StoneEdgeFixtures.hs
@@ -244,8 +244,8 @@ orderOtherDataXml =
 ><Comments
 >Long, Multiline
 Customer Comments</Comments
-><CustomerID
->9001</CustomerID
+><WebCustomerID
+>9001</WebCustomerID
 ></Other
 >|]
 


### PR DESCRIPTION
Currently, the website's customer ID is returned as 'Order/Other/ CustomerID'. However, Stone Edge expects it to be 'Order/Other/ WebCustomerID'.

The returned XML key is now fixed and new customers in Stone Edge should have valid mapping with customers on the website.