### PR TITLE
[Chore] Use 'persistent-migration' DB migrations management

### DIFF
--- a/server/app/Main.hs
+++ b/server/app/Main.hs
@@ -11,7 +11,7 @@ import Control.Concurrent.STM (newTVarIO, writeTVar, atomically)
 import Control.Exception (Exception(..), SomeException)
 import Control.Immortal.Queue (processImmortalQueue, closeImmortalQueue)
 import Control.Monad (when, forever, void, forM_)
-import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Logger (MonadLoggerIO, runNoLoggingT, runStderrLoggingT)
 import Data.Aeson (Result(..), fromJSON)
 import Data.Maybe (fromMaybe, mapMaybe)
@@ -155,7 +155,7 @@ main = do
             let action :: (MonadIO m, MonadLoggerIO m, MonadUnliftIO m) => m ConnectionPool
                 action = do
                     pool <- makeSqlPool $ poolSize env
-                    runSqlPool (runMigration migrateAll) pool
+                    liftIO $ runSqlPool runMigrations pool
                     return pool
             case env of
                 Production -> runNoLoggingT action

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -78,6 +78,7 @@ dependencies:
     - network
     - pandoc
     - persistent
+    - persistent-migration
     - persistent-postgresql
     - persistent-template
     - pureMD5
@@ -146,6 +147,7 @@ tests:
             - tasty
             - tasty-hedgehog
             - tasty-hunit
+            - testcontainers
             - hedgehog
             - HUnit
             - raw-strings-qq

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -8,10 +8,11 @@ packages:
 extra-deps:
     - state-codes-0.1.3@sha256:61981a09694973bf03b87309610b744ea4c8570fed3d20f1876933f572bbdf2b,1611
     - cereal-time-0.1.0.0@sha256:2ad5cb0e7bdd0fa8b6cbdfcfe6b9259efb2a188e33c3ce039155d63edda51ffc,1604
+    - persistent-migration-0.3.0@sha256:1b28e22c2eeff694eed6835299b3a80104772d5d2262e6dbfa5c47d9e7594f59,3433
+    - testcontainers-0.5.1.0@sha256:8cbda2cc2c395df7725eb1a85b0a99eaa749a5e7c53e26059c12290a9ec6f7c4,2612
 
 allow-newer: true
 
 flags: {}
 
 extra-package-dbs: []
-

--- a/server/stack.yaml.lock
+++ b/server/stack.yaml.lock
@@ -18,6 +18,20 @@ packages:
       size: 635
   original:
     hackage: cereal-time-0.1.0.0@sha256:2ad5cb0e7bdd0fa8b6cbdfcfe6b9259efb2a188e33c3ce039155d63edda51ffc,1604
+- completed:
+    hackage: persistent-migration-0.3.0@sha256:1b28e22c2eeff694eed6835299b3a80104772d5d2262e6dbfa5c47d9e7594f59,3433
+    pantry-tree:
+      sha256: dca2b30b726ac3ee8e5a556fe78f50c1714d3d8bf9c02b66f645de60b221f3b9
+      size: 1619
+  original:
+    hackage: persistent-migration-0.3.0@sha256:1b28e22c2eeff694eed6835299b3a80104772d5d2262e6dbfa5c47d9e7594f59,3433
+- completed:
+    hackage: testcontainers-0.5.1.0@sha256:8cbda2cc2c395df7725eb1a85b0a99eaa749a5e7c53e26059c12290a9ec6f7c4,2612
+    pantry-tree:
+      sha256: 24147f604397f87aed63562f9bfb8007524aa9347d71d5062bc75c2fd58d1ac8
+      size: 1331
+  original:
+    hackage: testcontainers-0.5.1.0@sha256:8cbda2cc2c395df7725eb1a85b0a99eaa749a5e7c53e26059c12290a9ec6f7c4,2612
 snapshots:
 - completed:
     sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68


### PR DESCRIPTION
Project has got to a point when migrations generated by 'mkMigrate'
no longer coverall use-cases and we need to provide non-trivial
migrations to convert data from one schema to another.

Migrations are now done via 'persitent-migration'.
Currently, there is only one migration that sets the inital DB scheme.

Migrations are applied on the application start so that only missing
migrations are done on launch.

Application additionally checks that persistent scheme matches
the DB and exits with an error if it doesn't.