### PR TITLE
[#58] Support multiple pictures per product on the backend

### DIFF
--- a/client/src/Cart.elm
+++ b/client/src/Cart.elm
@@ -17,7 +17,7 @@ import Html.Keyed as Keyed
 import Json.Encode as Encode
 import Models.Fields exposing (Cents(..), centsMap, imageToSrcSet, imgSrcFallback, lotSizeToString)
 import PageData exposing (CartDetails, CartItemId(..))
-import Product exposing (variantPrice)
+import Product exposing (productMainImage, variantPrice)
 import RemoteData
 import Routing exposing (Route(..), reverse)
 import User exposing (AuthStatus, unauthorized)
@@ -234,8 +234,8 @@ view authStatus ({ quantities } as form_) ({ items, charges } as cartDetails) =
                             :: routeLinkAttributes (ProductDetails product.slug <| Just variant.id)
                         )
                         [ img
-                            [ src <| imgSrcFallback product.image
-                            , imageToSrcSet product.image
+                            [ src <| imgSrcFallback (productMainImage product)
+                            , imageToSrcSet (productMainImage product)
                             , productImageSizes
                             , class "cart-product-image"
                             , alt <| "Product Image for " ++ product.name
@@ -333,13 +333,15 @@ mobileCartTable : Form -> CartDetails -> { subTotal : Cents, total : Cents } -> 
 mobileCartTable { quantities } { items, charges } totals =
     let
         cartRow { id, product, variant } =
+            let productImage = productMainImage product
+            in
             div [ class "cart-mobile-product row py-4" ]
                 [ div [ class "col-4 mb-3" ]
                     [ a (routeLinkAttributes <| ProductDetails product.slug <| Just variant.id)
                         [ img
                             [ class "img-fluid"
-                            , src <| imgSrcFallback product.image
-                            , imageToSrcSet product.image
+                            , src <| imgSrcFallback productImage
+                            , imageToSrcSet productImage
                             , productImageSizes
                             ]
                             []

--- a/client/src/Checkout.elm
+++ b/client/src/Checkout.elm
@@ -26,7 +26,7 @@ import Models.Fields exposing (Cents(..), centsFromString, centsMap, centsMap2, 
 import OrderDetails
 import PageData exposing (LineItemType(..))
 import Ports
-import Product exposing (variantPrice)
+import Product exposing (productMainImage, variantPrice)
 import RemoteData exposing (WebData)
 import Routing exposing (Route(..), reverse)
 import Time
@@ -1639,11 +1639,13 @@ summaryTable ({ items, charges } as checkoutDetails) creditString couponCode cou
                 ]
 
         productRow { product, variant, quantity } =
+            let productImage = productMainImage product
+            in
             tr []
                 [ td [ class "align-middle text-center" ]
                     [ img
-                        [ src <| imgSrcFallback product.image
-                        , imageToSrcSet product.image
+                        [ src <| imgSrcFallback productImage
+                        , imageToSrcSet productImage
                         , imageSizes
                         , alt <| "Product Image for " ++ product.name
                         ]
@@ -1661,11 +1663,13 @@ summaryTable ({ items, charges } as checkoutDetails) creditString couponCode cou
                 ]
 
         mobileRow { product, variant, quantity } =
+            let productImage = productMainImage product
+            in
             div [ class "row" ]
                 [ div [ class "col-auto pr-0" ]
                     [ img
-                        [ src <| imgSrcFallback product.image
-                        , imageToSrcSet product.image
+                        [ src <| imgSrcFallback productImage
+                        , imageToSrcSet productImage
                         , imageSizes
                         ]
                         []

--- a/client/src/Main.elm
+++ b/client/src/Main.elm
@@ -31,7 +31,7 @@ import PageData exposing (CartItemId(..), PageData)
 import Paginate exposing (Paginated)
 import Ports
 import Process
-import Product exposing (ProductId(..), ProductVariantId(..))
+import Product exposing (ProductId(..), ProductVariantId(..), productMainImage)
 import Products.AdminViews as ProductAdmin
 import QuickOrder
 import RemoteData exposing (WebData)
@@ -892,7 +892,7 @@ update msg ({ pageData, key } as model) =
         ProductDetailsLightbox subMsg ->
             let
                 updateLightbox { product } =
-                    Gallery.update imageDataLightboxConfig subMsg model.productDetailsLightbox [ product.image ]
+                    Gallery.update imageDataLightboxConfig subMsg model.productDetailsLightbox [ productMainImage product ]
             in
             pageData.productDetails
                 |> RemoteData.toMaybe

--- a/client/src/Product.elm
+++ b/client/src/Product.elm
@@ -9,6 +9,7 @@ module Product exposing
     , isLimitedAvailablity
     , isOutOfStock
     , nameWithLotSize
+    , productMainImage
     , singleVariantName
     , variantDecoder
     , variantPrice
@@ -20,7 +21,7 @@ import Html.Attributes exposing (class)
 import Json.Decode as Decode exposing (Decoder)
 import Json.Encode as Encode exposing (Value)
 import Markdown exposing (defaultOptions)
-import Models.Fields exposing (Cents(..), ImageData, LotSize, imageDecoder, lotSizeDecoder, lotSizeToString)
+import Models.Fields exposing (Cents(..), ImageData, LotSize, blankImage, imageDecoder, lotSizeDecoder, lotSizeToString)
 import Views.Microdata as Microdata
 
 
@@ -44,7 +45,7 @@ type alias Product =
     , slug : String
     , baseSKU : String
     , longDescription : String
-    , image : ImageData
+    , images : List ImageData
     }
 
 
@@ -80,6 +81,9 @@ singleVariantName product variants =
                 { lotSize = Nothing }
 
 
+productMainImage : Product -> ImageData
+productMainImage product = List.head product.images |> Maybe.withDefault blankImage
+
 decoder : Decoder Product
 decoder =
     Decode.map6 Product
@@ -88,7 +92,7 @@ decoder =
         (Decode.field "slug" Decode.string)
         (Decode.field "baseSku" Decode.string)
         (Decode.field "longDescription" Decode.string)
-        (Decode.field "image" imageDecoder)
+        (Decode.field "images" (Decode.list imageDecoder))
 
 
 type ProductVariantId

--- a/client/src/Products/Views.elm
+++ b/client/src/Products/Views.elm
@@ -10,7 +10,7 @@ import Html.Keyed as Keyed
 import Json.Decode as Decode
 import Messages exposing (Msg(..))
 import Model exposing (CartForms)
-import Models.Fields exposing (Cents(..), centsToString, imageToSrcSet, imgSrcFallback, lotSizeToString)
+import Models.Fields exposing (Cents(..), blankImage, centsToString, imageToSrcSet, imgSrcFallback, lotSizeToString)
 import PageData exposing (ProductData)
 import Paginate exposing (Paginated)
 import Product exposing (Product, ProductId(..), ProductVariant, ProductVariantId(..), variantPrice)
@@ -24,6 +24,7 @@ import Views.Format as Format
 import Views.Microdata as Microdata
 import Views.Pager as Pager
 import Views.Utils exposing (htmlOrBlank, icon, numericInput, onIntInput, rawHtml, routeLinkAttributes)
+import Product exposing (productMainImage)
 
 
 details : CartForms -> PageData.ProductDetails -> List (Html Msg)
@@ -41,6 +42,7 @@ details addToCartForms { product, variants, maybeSeedAttribute, categories } =
                             , rawHtml category.description
                             ]
                     )
+        productImage = productMainImage product
     in
     List.singleton <|
         div Microdata.product
@@ -59,14 +61,14 @@ details addToCartForms { product, variants, maybeSeedAttribute, categories } =
                             [ class "card" ]
                             [ div [ class "card-body text-center p-1" ]
                                 [ a
-                                    [ href <| product.image.original
+                                    [ href <| productImage.original
                                     , A.target "_self"
-                                    , Gallery.openOnClick ProductDetailsLightbox product.image
+                                    , Gallery.openOnClick ProductDetailsLightbox productImage
                                     , Aria.label <| "View Product Image for " ++ product.name
                                     ]
                                     [ img
-                                        [ src <| imgSrcFallback product.image
-                                        , imageToSrcSet product.image
+                                        [ src <| imgSrcFallback productImage
+                                        , imageToSrcSet productImage
                                         , class "img-fluid mb-2"
                                         , alt <| "Product Image for " ++ product.name
                                         , Microdata.image
@@ -177,6 +179,8 @@ list routeConstructor pagination addToCartForms products =
                 |> List.foldr (\( r, b ) ( rs, bs ) -> ( r :: rs, b :: bs )) ( [], [] )
 
         renderProduct cartData ( product, variants, maybeSeedAttribute ) =
+            let productImage = productMainImage product
+            in
             tr Microdata.product
                 [ td [ class "row-product-image text-center align-middle" ]
                     [ Keyed.node "a"
@@ -185,8 +189,8 @@ list routeConstructor pagination addToCartForms products =
                         )
                         [ ( "product-img-" ++ (String.fromInt <| (\(ProductId i) -> i) product.id)
                           , img
-                                [ src <| imgSrcFallback product.image
-                                , imageToSrcSet product.image
+                                [ src <| imgSrcFallback productImage
+                                , imageToSrcSet productImage
                                 , listImageSizes
                                 , Microdata.image
                                 , alt <| "Product Image for " ++ product.name
@@ -270,6 +274,7 @@ renderMobileProductBlock { maybeSelectedVariantId, maybeSelectedVariant, variant
 
             else
                 text ""
+        productImage = productMainImage product
     in
     form formAttributes <|
         [ div [ class "col-12 col-sm-4 pr-sm-0 mb-sm-2" ]
@@ -279,8 +284,8 @@ renderMobileProductBlock { maybeSelectedVariantId, maybeSelectedVariant, variant
                 )
                 [ ( "product-img-" ++ (String.fromInt <| (\(ProductId i) -> i) product.id)
                   , img
-                        [ src <| imgSrcFallback product.image
-                        , imageToSrcSet product.image
+                        [ src <| imgSrcFallback productImage
+                        , imageToSrcSet productImage
                         , class "img-fluid"
                         , listImageSizes
                         , alt <| "Product Image for " ++ product.name

--- a/client/src/View.elm
+++ b/client/src/View.elm
@@ -25,6 +25,7 @@ import Model exposing (CartForms, Model)
 import OrderDetails
 import PageData
 import Paginate
+import Product exposing (productMainImage)
 import Products.AdminViews as ProductAdmin
 import Products.Pagination as Pagination
 import Products.Views as ProductViews
@@ -574,7 +575,7 @@ pageImage { route, pageData } =
     case route of
         ProductDetails _ _ ->
             RemoteData.toMaybe pageData.productDetails
-                |> Maybe.map (.product >> .image >> .original)
+                |> Maybe.map (.product >> productMainImage >> .original)
 
         CategoryDetails _ _ ->
             Paginate.getResponseData pageData.categoryDetails

--- a/server/scripts/ExportProductsRacks.hs
+++ b/server/scripts/ExportProductsRacks.hs
@@ -6,6 +6,7 @@
 import Control.Monad.Logger (runNoLoggingT)
 import Data.Csv (ToNamedRecord, DefaultOrdered(..), encodeDefaultOrderedByName)
 import Data.List (sortOn)
+import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Time (formatTime, defaultTimeLocale)
 import Database.Persist
 import Database.Persist.Postgresql
@@ -77,7 +78,7 @@ makeExportData (Entity _ ProductVariant {..}, Entity _ Product {..}, maybeAttrib
         , price = formatCents productVariantPrice
         , lotSize = maybe "" renderLotSize productVariantLotSize
         , description = productLongDescription
-        , imageUrl = "https://southernexposure.com/media/products/originals/" <> productImageUrl
+        , imageUrl = "https://southernexposure.com/media/products/originals/" <> fromMaybe "" (listToMaybe productImageUrls)
         , isOrganic = getStatus seedAttributeIsOrganic maybeAttribute
         , isHeirloom = getStatus seedAttributeIsHeirloom maybeAttribute
         , isSmallGrower = getStatus seedAttributeIsSmallGrower maybeAttribute

--- a/server/src/Routes/CommonData.hs
+++ b/server/src/Routes/CommonData.hs
@@ -118,7 +118,7 @@ data BaseProductData =
         , bpdSlug :: T.Text
         , bpdBaseSku :: T.Text
         , bpdLongDescription :: T.Text
-        , bpdImage :: ImageSourceSet
+        , bpdImages :: [ImageSourceSet]
         , bpdCategories :: [CategoryId]
         , bpdShippingRestrictions :: [Region]
         } deriving (Show)
@@ -131,20 +131,20 @@ instance ToJSON BaseProductData where
             , "slug" .= bpdSlug
             , "baseSku" .= bpdBaseSku
             , "longDescription" .= bpdLongDescription
-            , "image" .= bpdImage
+            , "images" .= bpdImages
             , "shippingRestrictions" .= bpdShippingRestrictions
             ]
 
 makeBaseProductData :: (MonadReader Config m, MonadIO m) => Entity Product -> [Entity ProductToCategory] -> m BaseProductData
 makeBaseProductData (Entity pId Product {..}) categories = do
-    image <- makeSourceSet "products" $ T.unpack productImageUrl
+    images <- mapM (makeSourceSet "products" . T.unpack) productImageUrls
     return BaseProductData
         { bpdId = pId
         , bpdName = productName
         , bpdSlug = productSlug
         , bpdBaseSku = productBaseSku
         , bpdLongDescription = productLongDescription
-        , bpdImage = image
+        , bpdImages = images
         , bpdCategories =
             productMainCategory
                 : map (productToCategoryCategoryId . entityVal) categories

--- a/server/src/Routes/Feeds.hs
+++ b/server/src/Routes/Feeds.hs
@@ -11,7 +11,7 @@ module Routes.Feeds
 import Control.Concurrent.STM (readTVarIO)
 import Control.Monad (forM)
 import Control.Monad.Reader (asks, liftIO)
-import Data.Maybe (listToMaybe)
+import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Scientific (Scientific, scientific)
 import Data.Time (UTCTime, getCurrentTime)
 import Database.Persist ((==.), (>=.), (<=.), Entity(..), selectList)
@@ -218,7 +218,7 @@ convertProduct baseUrl checkoutDisabled predCache categoryMap prodSales catSales
         , pTitle = productName prod <> lotSize
         , pDescription = productLongDescription prod
         , pLink = productUrl <> productSlug prod <> "/" <> "?variant=" <> T.pack (show $ E.fromSqlKey variantId)
-        , pImageLink = imageUrl <> productImageUrl prod
+        , pImageLink = imageUrl <> fromMaybe "" (listToMaybe $ productImageUrls prod)
         , pProductType = categoryHierarchy
         , pGoogleProductType = Just googleCategory
         , pPriceData =


### PR DESCRIPTION
We need to be able to store and show multiple pictures per product.

To support this, the DB was migrated to store multiple product image URLs as 'PersistentList' and the API was updated to handle the data for multiple images.

Frontend was adjusted to peek the first returned image or show the blank image if the list is empty.

Related to #58 