### PR TITLE
Hotfix tailwind check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: client
         run: |
           npm run tailwind
-          git diff --exit-code || echo "Tailwind CSS needs to be built. Please run 'npm run tailwind' before committing."
+          git diff --exit-code || (echo "Tailwind CSS needs to be built. Please run 'npm run tailwind' before committing."; exit 1)
 
       - name: Build Client Project
         working-directory: client


### PR DESCRIPTION
Make CI actually fail when tailwin-output.css is outdated.