### PR TITLE
[#64] Consider 'out of stock' in the cart and during checkout

### DIFF
--- a/client/src/Main.elm
+++ b/client/src/Main.elm
@@ -1493,6 +1493,9 @@ update msg ({ pageData, key } as model) =
 
                         _ ->
                             pageData
+                validateCart m = Cmd.map
+                    CheckoutMsg
+                    (Checkout.validateCart m.currentUser m.maybeSessionToken m.pageData.checkoutDetails)
 
                 cmd =
                     case response of
@@ -1506,8 +1509,7 @@ update msg ({ pageData, key } as model) =
                         _ ->
                             Cmd.none
             in
-            extraCommand (redirect403IfAnonymous key response) <|
-                (\a -> Tuple.pair a cmd) <|
+                ((\a -> Tuple.pair a cmd) <|
                     case ( pageData.checkoutDetails, response ) of
                         ( RemoteData.Success _, RemoteData.Success (Ok _) ) ->
                             { model | pageData = updatedPageData }
@@ -1524,6 +1526,9 @@ update msg ({ pageData, key } as model) =
 
                         _ ->
                             { model | pageData = updatedPageData }
+                )
+                |> extraCommand (redirect403IfAnonymous key response)
+                |> extraCommand validateCart
 
         GetCheckoutSuccessDetails response ->
             let

--- a/client/src/Messages.elm
+++ b/client/src/Messages.elm
@@ -61,7 +61,7 @@ type Msg
     | IncreaseCartFormQuantity ProductId
     | DecreaseCartFormQuantity ProductId
     | SubmitAddToCart ProductId ProductVariantId
-    | SubmitAddToCartResponse ProductId Int (WebData String)
+    | SubmitAddToCartResponse ProductId Int (WebData (Result Api.FormErrors String))
     | ResetCartFormStatus ProductId
       -- My Account Page
     | ShowAllOrders

--- a/client/src/Model.elm
+++ b/client/src/Model.elm
@@ -93,7 +93,6 @@ type alias Model =
     , profileNavbar : ProfileNavbar.Model
     }
 
-
 initial : Routing.Key -> Route -> String -> Model
 initial key route helcimUrl =
     { navigationData = RemoteData.Loading

--- a/client/src/Pages/Cart/Type.elm
+++ b/client/src/Pages/Cart/Type.elm
@@ -1,5 +1,6 @@
 module Pages.Cart.Type exposing (..)
 
+import Api exposing (FormErrors)
 import Dict exposing (Dict)
 import Html exposing (..)
 import RemoteData
@@ -12,16 +13,17 @@ type alias CartForms =
     Dict Int
         { variant : Maybe ProductVariantId
         , quantity : Int
-        , requestStatus : WebData ()
+        , requestStatus : WebData (Result Api.FormErrors ())
         }
 
 type alias Form =
     { quantities : Dict Int Int
+    , errors : FormErrors
     }
 
 initial : Form
 initial =
-    Form Dict.empty
+    Form Dict.empty Dict.empty
 
 -- UPDATE
 
@@ -32,5 +34,5 @@ type Msg
     | DecreaseFormQuantity PageData.CartItemId
     | Remove PageData.CartItemId
     | Submit
-    | UpdateResponse (RemoteData.WebData PageData.CartDetails)
+    | UpdateResponse (RemoteData.WebData (Result FormErrors PageData.CartDetails))
 

--- a/client/src/Products/Views.elm
+++ b/client/src/Products/Views.elm
@@ -5,7 +5,7 @@ import Category exposing (Category)
 import Components.Button as Button exposing (ButtonType(..), defaultButton)
 import Components.Form as Form
 import Components.Svg exposing (minusSvg, plusSvg, shoppingCartSvgSmall)
-import Dict exposing (Dict)
+import Dict exposing (Dict, get)
 import Html exposing (..)
 import Html.Attributes as A exposing (alt, attribute, class, for, href, id, selected, src, title, type_, value)
 import Html.Events exposing (on, onClick, onSubmit, targetValue)
@@ -205,10 +205,27 @@ cartFormData addToCartForms ( product, variants ) =
                         , text "Adding to Cart"
                         ]
 
-                RemoteData.Success _ ->
+                RemoteData.Success (Ok _) ->
                     div [ class "tw:py-[8px] tw:text-[rgb(77,170,154)] font-weight-bold small" ]
                         [ icon "check-circle mr-1"
                         , text "Added to Cart!"
+                        ]
+
+                RemoteData.Success (Err errors) ->
+                    div [ class "tw:py-[8px] text-danger font-weight-bold small" ]
+                        [ icon "times mr-1"
+                        , text "Error Adding To Cart: "
+                        , br [] []
+                        , case get "variant" errors of
+                            Just variantValidation ->
+                                text <| " " ++ String.join "\n" variantValidation
+                            Nothing ->
+                                text ""
+                        , case get "quantity" errors of
+                            Just quantityValidation ->
+                                text <| " " ++ String.join "\n" quantityValidation
+                            Nothing ->
+                                text ""
                         ]
 
                 RemoteData.Failure _ ->

--- a/server/src/Routes/Carts.hs
+++ b/server/src/Routes/Carts.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE TypeFamilies #-}
 module Routes.Carts
     ( CartAPI
+    , ValidateCartParameters(..)
     , cartRoutes
     ) where
 

--- a/server/src/Routes/Carts.hs
+++ b/server/src/Routes/Carts.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeFamilies #-}
 module Routes.Carts
@@ -9,7 +10,7 @@ module Routes.Carts
     , cartRoutes
     ) where
 
-import Control.Monad ((>=>), void, when)
+import Control.Monad ((>=>), forM, void, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans (lift)
 import Data.Aeson ((.:), (.:?), (.=), FromJSON(..), ToJSON(..), object, withObject)
@@ -134,12 +135,18 @@ instance FromJSON CustomerAddParameters where
             <$> v .: "variant"
             <*> v .: "quantity"
 
-instance Validation CustomerAddParameters where
+data CustomerAddCartParameters = CustomerAddCartParameters
+    { cacpVariantId :: ProductVariantId
+    , cacpQuantity :: Natural
+    , cacpCartId :: CartId
+    }
+
+instance Validation CustomerAddCartParameters where
     validators parameters = do
-        variantErrors <- validateVariant $ capVariantId parameters
+        variantErrors <- validateVariant (cacpVariantId parameters) (cacpQuantity parameters) (cacpCartId parameters)
         return [ ( "variant", variantErrors )
                , ( "quantity"
-                 , [ V.zeroOrPositive $ capQuantity parameters
+                 , [ V.zeroOrPositive $ cacpQuantity parameters
                    ]
                  )
                ]
@@ -150,23 +157,23 @@ type CustomerAddRoute =
      :> Post '[JSON] (Cookied ())
 
 customerAddRoute :: WrappedAuthToken -> CustomerAddParameters -> App (Cookied ())
-customerAddRoute = validateCookieAndParameters $ \(Entity customerId _) parameters ->
-    let
-        productVariant =
-            capVariantId parameters
-        quantity =
-            capQuantity parameters
-        item cartId =
-            CartItem
-                { cartItemCartId = cartId
-                , cartItemProductVariantId = productVariant
-                , cartItemQuantity = fromIntegral quantity
-                }
-    in do
-        (Entity cartId _) <- getOrCreateCustomerCart customerId
+customerAddRoute token parameters = withCookie token $ \authToken -> do
+    (Entity customerId _) <- validateToken authToken
+    (Entity cartId _) <- getOrCreateCustomerCart customerId
+    validate (CustomerAddCartParameters (capVariantId parameters) (capQuantity parameters) cartId) >> do
+        let
+            productVariant =
+                capVariantId parameters
+            quantity =
+                capQuantity parameters
+            item =
+                CartItem
+                    { cartItemCartId = cartId
+                    , cartItemProductVariantId = productVariant
+                    , cartItemQuantity = fromIntegral quantity
+                    }
         void . runDB $ upsertBy (UniqueCartItem cartId productVariant)
-            (item cartId) [CartItemQuantity +=. fromIntegral quantity]
-
+            item [CartItemQuantity +=. fromIntegral quantity]
 
 data AnonymousAddParameters =
     AnonymousAddParameters
@@ -182,12 +189,18 @@ instance FromJSON AnonymousAddParameters where
             <*> v .: "quantity"
             <*> v .:? "sessionToken"
 
-instance Validation AnonymousAddParameters where
+data AnonymousAddCartParameters = AnonymousAddCartParameters
+    { aacpVariantId :: ProductVariantId
+    , aacpQuantity :: Natural
+    , aacpCartId :: CartId
+    }
+
+instance Validation AnonymousAddCartParameters where
     validators parameters = do
-        variantErrors <- validateVariant $ aapVariantId parameters
+        variantErrors <- validateVariant (aacpVariantId parameters) (aacpQuantity parameters) (aacpCartId parameters)
         return [ ( "variant", variantErrors )
                , ( "quantity"
-                 , [ V.zeroOrPositive $ aapQuantity parameters
+                 , [ V.zeroOrPositive $ aacpQuantity parameters
                    ]
                  )
                ]
@@ -197,47 +210,53 @@ type AnonymousAddRoute =
     :> Post '[PlainText] T.Text
 
 anonymousAddRoute :: AnonymousAddParameters -> App T.Text
-anonymousAddRoute = validate >=> \parameters ->
-    let
-        productVariant =
-            aapVariantId parameters
-        quantity =
-            aapQuantity parameters
-        maybeSessionToken =
-            aapSessionToken parameters
-        item cartId =
-            CartItem
-                { cartItemCartId = cartId
-                , cartItemProductVariantId = productVariant
-                , cartItemQuantity = fromIntegral quantity
-                }
-    in do
-        (token, Entity cartId _) <- getOrCreateAnonymousCart maybeSessionToken
+anonymousAddRoute parameters = do
+    (token, Entity cartId _) <- getOrCreateAnonymousCart (aapSessionToken parameters)
+    validate (AnonymousAddCartParameters (aapVariantId parameters) (aapQuantity parameters) cartId) >> do
+        let
+            productVariant =
+                aapVariantId parameters
+            quantity =
+                aapQuantity parameters
+            item =
+                CartItem
+                    { cartItemCartId = cartId
+                    , cartItemProductVariantId = productVariant
+                    , cartItemQuantity = fromIntegral quantity
+                    }
         void . runDB $ upsertBy (UniqueCartItem cartId productVariant)
-            (item cartId) [CartItemQuantity +=. fromIntegral quantity]
+            item [CartItemQuantity +=. fromIntegral quantity]
         return token
 
 
 -- | Ensure a Variant exists, is active, and is not sold out.
-validateVariant :: ProductVariantId -> App [(T.Text, Bool)]
-validateVariant variantId =
+validateVariant :: ProductVariantId -> Natural -> CartId -> App [(T.Text, Bool)]
+validateVariant variantId purchaseAmount cartId =
     runDB $ get variantId >>= \case
         Nothing ->
             return
-                [ ( "This Product Variant Does Not Exist.", True ) ]
-        Just variant ->
+                [ ( "This Product Does Not Exist.", True ) ]
+        Just variant -> do
+            mbCartQuantity <- fmap (fmap E.unValue . listToMaybe) <$> E.select $ do
+                (c E.:& ci) <- E.from $ E.table @Cart
+                    `E.innerJoin` E.table @CartItem
+                    `E.on` \(c E.:& ci) -> ci E.^. CartItemCartId E.==. c E.^. CartId
+                E.where_ $ c E.^. CartId E.==. E.val cartId
+                E.where_ $ ci E.^. CartItemProductVariantId E.==. E.val variantId
+                return $ ci E.^. CartItemQuantity
+
             let inactiveError =
-                    [ ( "This Product Variant is Inactive."
+                    [ ( "This Product is Inactive."
                         , not (productVariantIsActive variant)
                         )
                     ]
                 soldOutError =
-                    [ ( "This Product Variant is Sold Out."
-                        , productVariantQuantity variant <= 0
+                    [ ( "This Product has less stock than requested. " <> "Available: " <> T.pack (show $ productVariantQuantity variant) <>
+                        ". Requested: " <> T.pack (show (purchaseAmount + maybe 0 fromIntegral mbCartQuantity)) <> "."
+                        , productVariantQuantity variant < fromIntegral purchaseAmount + maybe 0 fromIntegral mbCartQuantity
                         )
                     ]
-            in
-            return $ inactiveError ++ soldOutError
+            return $ inactiveError <> soldOutError
 
 
 -- DETAILS
@@ -309,23 +328,21 @@ instance FromJSON CustomerUpdateParameters where
         CustomerUpdateParameters
             <$> v .: "quantities"
 
-instance Validation CustomerUpdateParameters where
-    validators parameters = return $
-        V.validateMap [V.zeroOrPositive] $ cupQuantities parameters
-
 type CustomerUpdateRoute =
        AuthProtect "cookie-auth"
     :> ReqBody '[JSON] CustomerUpdateParameters
     :> Post '[JSON] (Cookied CartDetailsData)
 
 customerUpdateRoute :: WrappedAuthToken -> CustomerUpdateParameters -> App (Cookied CartDetailsData)
-customerUpdateRoute = validateCookieAndParameters $ \customer@(Entity customerId _) parameters -> do
+customerUpdateRoute token parameters = withCookie token $ \authToken -> do
+    customer@(Entity customerId _) <- validateToken authToken
     maybeCart <- runDB . getBy . UniqueCustomerCart $ Just customerId
     case maybeCart of
         Nothing ->
             serverError err404
-        Just (Entity cartId _) ->
-            updateOrDeleteItems cartId $ cupQuantities parameters
+        Just (Entity cartId _) -> do
+            validate (ValidateCartParameters cartId (cupQuantities parameters)) >> do
+                updateOrDeleteItems cartId $ cupQuantities parameters
     getCustomerCartDetails customer
 
 
@@ -341,10 +358,6 @@ instance FromJSON AnonymousUpdateParameters where
             <$> v .: "sessionToken"
             <*> v .: "quantities"
 
-instance Validation AnonymousUpdateParameters where
-    validators parameters = return $
-        V.validateMap [ V.zeroOrPositive ] $ aupQuantities parameters
-
 type AnonymousUpdateRoute =
        ReqBody '[JSON] AnonymousUpdateParameters
     :> Post '[JSON] CartDetailsData
@@ -357,7 +370,8 @@ anonymousUpdateRoute parameters = do
         Nothing ->
             serverError err404
         Just (Entity cartId _) ->
-            updateOrDeleteItems cartId $ aupQuantities parameters
+            validate (ValidateCartParameters cartId (aupQuantities parameters)) >> do
+                updateOrDeleteItems cartId $ aupQuantities parameters
     anonymousDetailsRoute $ AnonymousDetailsParameters token
 
 
@@ -375,6 +389,32 @@ updateOrDeleteItems cartId =
         )
         (return ())
 
+
+data ValidateCartParameters = ValidateCartParameters CartId (M.Map Int64 Natural)
+
+instance Validation ValidateCartParameters where
+    validators (ValidateCartParameters cartId quantities) =
+        runDB $ forM (M.toList quantities) $ \(itemId, quantity) -> (T.pack $ show itemId,) <$> do
+            let nonNegativeQuantityValidation = V.zeroOrPositive quantity
+            mbVariantQuantity <- fmap (fmap E.unValue . listToMaybe) <$> E.select $ do
+                (c E.:& ci E.:& pv) <- E.from $ E.table @Cart
+                    `E.innerJoin` E.table @CartItem
+                        `E.on` (\(c E.:& ci) -> ci E.^. CartItemCartId E.==. c E.^. CartId)
+                    `E.innerJoin` E.table @ProductVariant
+                        `E.on` (\(_c E.:& ci E.:& pv) -> ci E.^. CartItemProductVariantId E.==. pv E.^. ProductVariantId)
+                E.where_ $ c E.^. CartId E.==. E.val cartId
+                E.where_ $ ci E.^. CartItemId E.==. E.val (toSqlKey itemId)
+                return $ pv E.^. ProductVariantQuantity
+            let variantStockValidation = case mbVariantQuantity of
+                    Nothing ->
+                        ("Product does not exist.", True)
+                    Just variantQuantity ->
+                        ( "This Product has less stock than requested. " <>
+                          "Available: " <> T.pack (show variantQuantity) <>
+                          ". Requested: " <> T.pack (show quantity) <> "."
+                        , variantQuantity < fromIntegral quantity
+                        )
+            return [nonNegativeQuantityValidation, variantStockValidation]
 
 -- COUNT
 


### PR DESCRIPTION
Problem: Currently, a product is considered 'out of stock' only when its quantity is zero. However, one can successfully buy arbitrary amount of such product if it has only 1 item in stock.

Solution: Consider existing QOH when adding item to the cart. Prohibit, it requested quantity is larger than available in stock.

This is the first PR within #64 scope.