### PR TITLE
[#78] Add address verification

### DIFF
--- a/client/src/Components/Address/Address.elm
+++ b/client/src/Components/Address/Address.elm
@@ -293,7 +293,6 @@ updateModel addressCompletionSetting msg model =
                                 , state = Just <| USState (String.toUpper addr.prov)
                                 , zipCode = addr.pc
                                 , country = String.toUpper addr.country
-                                , warnings = addr.errors
                             }
                     in
                     ( newModel, Cmd.none )
@@ -805,7 +804,6 @@ viewSuggestion suggestion =
     in
     li [ class "tw:p-[8px] tw:hover:bg-gray-200 tw:cursor-pointer", onClick (SuggestionSelected suggestion) ]
         [ text suggestionText ]
-
 
 viewWarnings : Model -> Html msg
 viewWarnings model =

--- a/client/src/Data/Api.elm
+++ b/client/src/Data/Api.elm
@@ -2,7 +2,7 @@ module Data.Api exposing
     ( Endpoint(..), get, post, put, patch, delete
     , withJsonBody, withStringResponse, withJsonResponse, withStringErrorHandler, withErrorHandler
     , sendRequest
-    , FormErrors, initialErrors, addError, prefixedArrayErrors
+    , FormErrors, initialErrors, addError, addErrors, prefixedArrayErrors
     , apiFailureToError, formErrorsDecoder
     , errorHtml, generalFormErrors, getErrorHtml
     )
@@ -580,14 +580,18 @@ formErrorsDecoder =
 
 addError : Field -> ErrorMessage -> FormErrors -> FormErrors
 addError field message errors =
+    addErrors field [ message ] errors
+
+addErrors : Field -> List ErrorMessage -> FormErrors -> FormErrors
+addErrors field messages errors =
     (\a -> Dict.update field a errors) <|
         \val ->
             case val of
                 Nothing ->
-                    Just [ message ]
+                    Just messages
 
                 Just es ->
-                    Just <| message :: es
+                    Just <| messages ++ es
 
 
 {-| Filter the FormErrors, keeping only errors for the given prefix & array

--- a/server/app/Main.hs
+++ b/server/app/Main.hs
@@ -41,6 +41,7 @@ import Models
 import Models.PersistJSON (JSONValue(..))
 import Paths_sese_website (version)
 import qualified Postgrid.API as Postgrid (ApiKey(..))
+import qualified Postgrid.Cache as Postgrid (newPostgridQueryCache)
 import StoneEdge (StoneEdgeCredentials(..))
 import Utils (lookupSettingWith, makeSqlPool)
 import Workers (Task(CleanDatabase, AddSalesReportDay), taskQueueConfig, enqueueTask)
@@ -83,6 +84,7 @@ main = do
     initializeJobs dbPool
     log "Initialized database pool."
     cache <- newTVarIO emptyCache
+    postgridQueryCache <- Postgrid.newPostgridQueryCache 10 100
     void . async
         $ runSqlPool initializeCaches dbPool >>= atomically . writeTVar cache
     log "Started initialization of database cache."
@@ -90,6 +92,7 @@ main = do
             { getPool = dbPool
             , getEnv = env
             , getCaches = cache
+            , getPostgridQueryCache = postgridQueryCache
             , getMediaDirectory = mediaDir
             , getSmtpPool = emailPool
             , getSmtpUser = smtpUser

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -125,6 +125,7 @@ library:
         - Models
         - Models.Fields
         - Models.PersistJSON
+        - Postgrid.API
         - Routes.Admin.ShippingMethods
         - Routes.CommonData
         - Routes.StoneEdge

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -63,6 +63,7 @@ dependencies:
     - esqueleto
     - fast-logger
     - filepath
+    - hashable
     - hostname
     - http-api-data
     - http-client
@@ -71,6 +72,7 @@ dependencies:
     - http-types
     - immortal-queue
     - iso3166-country-codes
+    - lrucaching
     - markdown
     - mime-mail
     - monad-logger
@@ -111,6 +113,7 @@ dependencies:
     - tagged
     - transformers
     - unliftio
+    - vector
 
 library:
     source-dirs: src
@@ -126,6 +129,7 @@ library:
         - Models.Fields
         - Models.PersistJSON
         - Postgrid.API
+        - Postgrid.Cache
         - Routes.Admin.ShippingMethods
         - Routes.CommonData
         - Routes.StoneEdge

--- a/server/src/Config.hs
+++ b/server/src/Config.hs
@@ -24,7 +24,7 @@ import StoneEdge (StoneEdgeCredentials)
 import qualified Avalara
 import qualified Helcim.API as Helcim (ApiToken)
 import qualified Postgrid.API as Postgrid (ApiKey)
-
+import qualified Postgrid.Cache as Postgrid (QueryCache)
 
 data Environment
     = Production
@@ -42,6 +42,7 @@ data Config
     { getPool :: ConnectionPool
     , getEnv :: Environment
     , getCaches :: TVar Caches
+    , getPostgridQueryCache :: Postgrid.QueryCache
     , getMediaDirectory :: FilePath
     , getSmtpPool :: Pool SMTPConnection
     , getSmtpUser :: String
@@ -72,6 +73,7 @@ defaultConfig =
         { getPool = undefined
         , getEnv = Development
         , getCaches = undefined
+        , getPostgridQueryCache = undefined
         , getMediaDirectory = undefined
         , getSmtpPool = undefined
         , getSmtpUser = undefined

--- a/server/src/Config.hs
+++ b/server/src/Config.hs
@@ -23,6 +23,7 @@ import StoneEdge (StoneEdgeCredentials)
 
 import qualified Avalara
 import qualified Helcim.API as Helcim (ApiToken)
+import qualified Postgrid.API as Postgrid (ApiKey)
 
 
 data Environment
@@ -47,6 +48,7 @@ data Config
     , getSmtpPass :: String
     , getStripeConfig :: StripeConfig
     , getHelcimAuthKey :: Helcim.ApiToken
+    , getPostgridApiKey :: Maybe Postgrid.ApiKey
     , getStoneEdgeAuth :: StoneEdgeCredentials
     , getCookieSecret :: PersistentServerKey
     , getCookieEntropySource :: RandomSource
@@ -59,6 +61,7 @@ data Config
     , getStripeLogger :: TimedFastLogger
     , getServerLogger :: TimedFastLogger
     , getHelcimLogger :: TimedFastLogger
+    , getPostgridLogger :: TimedFastLogger
     , getDeveloperEmail :: Maybe Text
     , getBaseUrl :: Text
     }
@@ -75,6 +78,7 @@ defaultConfig =
         , getSmtpPass = undefined
         , getStripeConfig = undefined
         , getHelcimAuthKey = undefined
+        , getPostgridApiKey = undefined
         , getStoneEdgeAuth = undefined
         , getCookieSecret = undefined
         , getCookieEntropySource = undefined
@@ -87,6 +91,7 @@ defaultConfig =
         , getStripeLogger = undefined
         , getServerLogger = undefined
         , getHelcimLogger = undefined
+        , getPostgridLogger = undefined
         , getDeveloperEmail = Nothing
         , getBaseUrl = "http://localhost:7000"
         }

--- a/server/src/Models/DB.hs
+++ b/server/src/Models/DB.hs
@@ -208,6 +208,7 @@ Address
     customerId CustomerId
     isActive Bool
     isDefault Bool
+    verified Bool default=false
     deriving Show
 
 
@@ -742,5 +743,9 @@ migrations =
     , 3 ~> 4 :=
         -- Add 'inventory_policy' to 'ProductVariant'
         [ AddColumn "product_variant" (Column "inventory_policy" SqlString [NotNull, Default $ toPersistValue AllowBackorder]) (Just $ toPersistValue AllowBackorder)
+        ]
+    , 4 ~> 5 :=
+        -- Add 'verified' to 'Address'
+        [ AddColumn "address" (Column "verified" SqlBool [NotNull, Default $ toPersistValue False]) (Just $ toPersistValue False)
         ]
     ]

--- a/server/src/Postgrid.hs
+++ b/server/src/Postgrid.hs
@@ -1,17 +1,22 @@
 module Postgrid
-    ( verifyStructuredAddress
+    ( AddressVerificationResult(..)
+    , verifyAddressData
     ) where
 
 import Control.Exception (displayException)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (asks, forM)
 import Data.Aeson (ToJSON, encode)
+import Data.ISO3166_CountryCodes (CountryCode(..))
 import Servant.Client (ClientM)
 
 import Postgrid.API.Types
+import Postgrid.Utils (addressDataToVerifyStructuredAddressRequest, correctAddressData)
 import qualified Postgrid.API as API
 
 import Config (Config(..), timedLogStr)
+import Models.Fields (AddressType(..), Country(..))
+import Routes.CommonData (AddressData(..))
 import Server (App)
 
 runPostgrid
@@ -34,13 +39,33 @@ runPostgrid clientFunc req = do
         log_ logger encoding logee =
             liftIO $ logger $ timedLogStr $ encoding logee
 
-verifyStructuredAddress
-    :: VerifyStructuredAddressRequest
-    -> App (Maybe (Either API.PostgridError VerifyStructuredAddressData))
-verifyStructuredAddress req = do
-    res <- runPostgrid
-        (\apiKey r -> API.verifyStructuredAddress apiKey Nothing (Just $ API.BoolFlag True) Nothing r) req
-    case res of
-        Just (Left err) -> return $ Just (Left err)
-        Just (Right resp) -> return $ Just (Right (vsarData resp))
-        Nothing -> return Nothing
+data AddressVerificationResult
+    = AddressVerifiedSuccessfully
+    | AddressCorrected AddressData VerifyStructuredAddressErrors
+    | AddressVerificationFailed VerifyStructuredAddressErrors
+
+verifyAddressData
+    :: AddressData
+    -> AddressType
+    -> App (Either API.PostgridError AddressVerificationResult)
+verifyAddressData addrData addrType = do
+    case (adCountry addrData, addrType) of
+        -- We only verify US shipping addresses at the moment
+        (Country US, Shipping) -> proceed
+        _ -> return $ Right AddressVerifiedSuccessfully
+    where
+        proceed = do
+            res <- runPostgrid
+                (\apiKey r -> API.verifyStructuredAddress apiKey Nothing (Just $ API.BoolFlag True) Nothing r)
+                    (addressDataToVerifyStructuredAddressRequest addrData)
+            case res of
+                Just (Left err) -> return $ Left err
+                Just (Right resp) ->
+                    let
+                        verificationData = vsarData resp
+                    in case vsadStatus verificationData of
+                            AVVerified -> return $ Right AddressVerifiedSuccessfully
+                            AVCorrected -> return $ Right $
+                                AddressCorrected (correctAddressData addrData verificationData) (vsadErrors verificationData)
+                            AVFailed -> return $ Right $ AddressVerificationFailed $ vsadErrors verificationData
+                Nothing -> return $ Right AddressVerifiedSuccessfully

--- a/server/src/Postgrid.hs
+++ b/server/src/Postgrid.hs
@@ -1,0 +1,46 @@
+module Postgrid
+    ( verifyStructuredAddress
+    ) where
+
+import Control.Exception (displayException)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (asks, forM)
+import Data.Aeson (ToJSON, encode)
+import Servant.Client (ClientM)
+
+import Postgrid.API.Types
+import qualified Postgrid.API as API
+
+import Config (Config(..), timedLogStr)
+import Server (App)
+
+runPostgrid
+    :: (PostgridResponse res, ToJSON req, ToJSON res)
+    => (Maybe API.ApiKey -> req -> ClientM res) -> req -> App (Maybe (Either API.PostgridError res))
+runPostgrid clientFunc req = do
+    apiKey <- asks getPostgridApiKey
+    forM apiKey $ \key -> do
+        logger <- asks getHelcimLogger
+        log_ logger encode req
+        res <- liftIO $ API.runPostgridClient (clientFunc (Just key) req)
+        case res of
+            Left err -> do
+                log_ logger displayException err
+                return $ Left err
+            Right resp -> do
+                log_ logger encode resp
+                return $ Right resp
+    where
+        log_ logger encoding logee =
+            liftIO $ logger $ timedLogStr $ encoding logee
+
+verifyStructuredAddress
+    :: VerifyStructuredAddressRequest
+    -> App (Maybe (Either API.PostgridError VerifyStructuredAddressData))
+verifyStructuredAddress req = do
+    res <- runPostgrid
+        (\apiKey r -> API.verifyStructuredAddress apiKey Nothing (Just $ API.BoolFlag True) Nothing r) req
+    case res of
+        Just (Left err) -> return $ Just (Left err)
+        Just (Right resp) -> return $ Just (Right (vsarData resp))
+        Nothing -> return Nothing

--- a/server/src/Postgrid/API.hs
+++ b/server/src/Postgrid/API.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
+module Postgrid.API
+    ( API
+    , ApiKey(..)
+    , AuthHeader
+    , BoolFlag(..)
+    , PostgridAddressVerificationAPI
+    , PostgridError(..)
+
+    , api
+    , baseUrl
+    , runPostgridClient
+    , verifyStructuredAddress
+    ) where
+
+import Control.Exception (Exception)
+import Data.Text (Text)
+import Network.HTTP.Client (newManager)
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Servant
+import Servant.Client (ClientM, client, BaseUrl(..), Scheme(..), ClientError(..), mkClientEnv, runClientM)
+
+import Postgrid.API.Types
+
+newtype ApiKey = ApiKey { unApiKey :: Text }
+    deriving (Show, Eq)
+    deriving newtype ToHttpApiData
+
+type AuthHeader = Header "x-api-key" ApiKey
+
+baseUrl :: BaseUrl
+baseUrl = BaseUrl Https "api.postgrid.com" 443 "/v1"
+
+newtype BoolFlag = BoolFlag { unBoolFlag :: Bool }
+    deriving (Show, Eq)
+
+instance ToHttpApiData BoolFlag where
+    -- Postgrid expects lowercase "true"/"false" strings for boolean query parameters
+    toQueryParam (BoolFlag True)  = "true"
+    toQueryParam (BoolFlag False) = "false"
+
+type PostgridAddressVerificationAPI =
+    "addver" :> "verifications" :> AuthHeader :>
+    QueryParam "includeDetails" BoolFlag :> QueryParam "properCase" BoolFlag :> QueryParam "geocode" BoolFlag :>
+    ReqBody '[JSON] VerifyStructuredAddressRequest :> Post '[JSON] VerifyStructuredAddressResponse
+
+type API = PostgridAddressVerificationAPI
+
+api :: Proxy API
+api = Proxy
+
+verifyStructuredAddress
+    :: Maybe ApiKey -> Maybe BoolFlag -> Maybe BoolFlag -> Maybe BoolFlag
+    -> VerifyStructuredAddressRequest
+    -> ClientM VerifyStructuredAddressResponse
+verifyStructuredAddress = client api
+
+data ApiError = ApiError
+    { aeStatus :: Text
+    , aeMessage :: Text
+    } deriving (Show, Eq)
+
+data PostgridError
+    = PostgridApiError ApiError
+    | PostgridClientError ClientError
+    deriving (Show, Eq)
+
+instance Exception PostgridError
+
+runPostgridClient :: PostgridResponse a => ClientM a -> IO (Either PostgridError a)
+runPostgridClient clientM = do
+    manager <- newManager tlsManagerSettings
+    let env = mkClientEnv manager baseUrl
+    res <- runClientM clientM env
+    case res of
+        Left err -> return $ Left (PostgridClientError err)
+        Right val -> case getStatus val of
+            "success" -> return $ Right val
+            _         -> return $ Left (PostgridApiError (ApiError (getStatus val) (getMessage val)))

--- a/server/src/Postgrid/API/Types.hs
+++ b/server/src/Postgrid/API/Types.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Postgrid.API.Types
+    ( AddressVerificationStatus(..)
+    , CountryCodeLowercase(..)
+    , PostgridResponse(..)
+    , VerifyStructuredAddressData(..)
+    , VerifyStructuredAddressErrors(..)
+    , VerifyStructuredAddressRequest(..)
+    , VerifyStructuredAddressRequestData(..)
+    , VerifyStructuredAddressResponse(..)
+    ) where
+
+import Data.Aeson (FromJSON(..), ToJSON(..), Value(..), withText)
+import Data.Aeson.TH (deriveJSON, deriveToJSON)
+import Data.ISO3166_CountryCodes (CountryCode)
+import Data.Map.Strict (Map)
+import Data.StateCodes (StateCode)
+import Data.Text (Text, pack, toLower, toUpper, unpack)
+import GHC.Generics (Generic)
+import Text.Read (readMaybe)
+
+import Postgrid.API.Utils (aesonOptions)
+
+-- postgrid uses lowercase country codes
+newtype CountryCodeLowercase = CountryCodeLowercase { unCountryCodeLowercase :: CountryCode }
+    deriving (Show, Eq)
+
+instance ToJSON CountryCodeLowercase where
+    toJSON (CountryCodeLowercase code) = String $ toLower (pack $ show code)
+
+instance FromJSON CountryCodeLowercase where
+    parseJSON = withText "Country" $ \t ->
+        case readMaybe (unpack $ toUpper t) of
+            Just countryCode ->
+                return $ CountryCodeLowercase countryCode
+            Nothing ->
+                fail $ "Invalid Country Code: " ++ unpack t
+
+
+-- https://postgrid.readme.io/reference/verify-a-structured-address-1
+
+newtype VerifyStructuredAddressRequest = VerifyStructuredAddressRequest
+    { vsarqAddress :: VerifyStructuredAddressRequestData
+    } deriving (Show, Generic)
+
+data VerifyStructuredAddressRequestData = VerifyStructuredAddressRequestData
+    { vsardRecipient       :: Maybe Text
+    , vsardLine1           :: Text
+    , vsardLine2           :: Maybe Text
+    , vsardCity            :: Text
+    , vsardProvinceOrState :: Text
+    , vsardPostalOrZip     :: Text
+    , vsardCountry         :: Text
+    } deriving (Show, Generic)
+
+-- Data type for the "errors" field
+newtype VerifyStructuredAddressErrors = VerifyStructuredAddressErrors
+    { vsaeErrors :: Map Text [Text]
+    } deriving (Show, Eq)
+
+instance FromJSON VerifyStructuredAddressErrors where
+    parseJSON v = VerifyStructuredAddressErrors <$> parseJSON v
+
+instance ToJSON VerifyStructuredAddressErrors where
+    toJSON (VerifyStructuredAddressErrors errs) = toJSON errs
+
+data AddressVerificationStatus
+    = AVVerified
+    | AVFailed
+    | AVCorrected
+    deriving (Show, Eq)
+
+instance FromJSON AddressVerificationStatus where
+    parseJSON (String "verified") = pure AVVerified
+    parseJSON (String "failed") = pure AVFailed
+    parseJSON (String "corrected") = pure AVCorrected
+    parseJSON _ = fail "Invalid AddressVerificationStatus"
+
+instance ToJSON AddressVerificationStatus where
+    toJSON AVVerified  = String "verified"
+    toJSON AVFailed   = String "failed"
+    toJSON AVCorrected = String "corrected"
+
+-- Data type for the "data" field
+data VerifyStructuredAddressData = VerifyStructuredAddressData
+    { vsadCity            :: Text
+    , vsadCountry         :: Maybe CountryCodeLowercase
+    , vsadCountryName     :: Maybe Text
+    , vsadErrors          :: VerifyStructuredAddressErrors
+    , vsadLine1           :: Text
+    , vsadPostalOrZip     :: Text
+    , vsadProvinceOrState :: StateCode
+    , vsadStatus          :: AddressVerificationStatus
+    } deriving (Show, Generic)
+
+class PostgridResponse a where
+    getStatus :: a -> Text
+    getMessage :: a -> Text
+
+data VerifyStructuredAddressResponse = VerifyStructuredAddressResponse
+    { vsarStatus  :: Text
+    , vsarMessage :: Text
+    , vsarData    :: VerifyStructuredAddressData
+    } deriving (Show, Generic)
+
+instance PostgridResponse VerifyStructuredAddressResponse where
+    getStatus = vsarStatus
+    getMessage = vsarMessage
+
+deriveJSON aesonOptions ''VerifyStructuredAddressData
+deriveJSON aesonOptions ''VerifyStructuredAddressResponse
+deriveToJSON aesonOptions ''VerifyStructuredAddressRequestData
+deriveToJSON aesonOptions ''VerifyStructuredAddressRequest

--- a/server/src/Postgrid/API/Utils.hs
+++ b/server/src/Postgrid/API/Utils.hs
@@ -1,0 +1,8 @@
+module Postgrid.API.Utils (aesonOptions) where
+
+import Data.Aeson.Casing (aesonPrefix, camelCase)
+import Data.Aeson.Types (Options(..))
+
+
+aesonOptions :: Options
+aesonOptions = (aesonPrefix camelCase) { omitNothingFields = True }

--- a/server/src/Postgrid/Cache.hs
+++ b/server/src/Postgrid/Cache.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Postgrid.Cache
+    ( CachedApiEndpoint(..)
+    , QueryCache(..)
+    , cached
+    , newPostgridQueryCache
+    ) where
+
+import Data.Aeson (encode)
+import Data.ByteString.Lazy (ByteString)
+import Data.IORef (atomicModifyIORef')
+import Data.Hashable (hash)
+import qualified Data.LruCache as Lru (lookup, insert)
+import Data.LruCache.IO (LruHandle(..), StripedLruHandle(..), newStripedLruHandle)
+import qualified Data.Vector as Vector
+
+import Postgrid.API (PostgridError)
+import Postgrid.API.Types
+
+data CachedApiEndpoint req resp where
+    CachedVerifyStructuredAddress :: CachedApiEndpoint VerifyStructuredAddressRequest VerifyStructuredAddressResponse
+
+cacheKey :: CachedApiEndpoint req resp -> req -> ByteString
+cacheKey CachedVerifyStructuredAddress = encode
+
+data CacheEntry where
+    CacheEntry :: CachedApiEndpoint req resp -> resp -> CacheEntry
+
+-- | In-memory cache for Postgrid API query results. It stores either a successful encoded response or an error.
+-- Encoded response is stored for the sake of memory efficiency.
+newtype QueryCache = QueryCache { unQueryCache :: StripedLruHandle ByteString CacheEntry }
+
+newPostgridQueryCache :: Int -> Int -> IO QueryCache
+newPostgridQueryCache numStripes size = QueryCache <$> newStripedLruHandle numStripes size
+
+-- | A helper for 'QueryCache' that checks the cache for a given request
+-- and either returns the cached response or runs the provided action to fetch it.
+-- Errors are not cached.
+cached :: QueryCache -> req -> CachedApiEndpoint req resp -> IO (Either PostgridError resp) -> IO (Either PostgridError resp)
+cached (QueryCache (StripedLruHandle handle)) req cachedApiEndpoint apiAction = do
+    let key = cacheKey cachedApiEndpoint req
+        idx = hash key `mod` Vector.length handle
+    cachedInternal (handle Vector.! idx) req cachedApiEndpoint apiAction
+
+-- | A custom version of Data.LruCache.IO.cache that doesn't cache errors.
+cachedInternal :: LruHandle ByteString CacheEntry -> req -> CachedApiEndpoint req resp -> IO (Either PostgridError resp) -> IO (Either PostgridError resp)
+cachedInternal (LruHandle ref) req cachedApiEndpoint apiAction = do
+    let key = cacheKey cachedApiEndpoint req
+    lookupRes <- atomicModifyIORef' ref $ \c ->
+        case Lru.lookup key c of
+            Nothing      -> (c,  Nothing)
+            Just (v, c') -> (c', Just v)
+    case (cachedApiEndpoint, lookupRes) of
+        (CachedVerifyStructuredAddress, Just (CacheEntry CachedVerifyStructuredAddress v)) -> return $ Right v
+        (_, Nothing) -> do
+            v <- apiAction
+            case v of
+                Left _ -> return v
+                Right resp -> do
+                    atomicModifyIORef' ref $ \c ->
+                        (Lru.insert key (CacheEntry cachedApiEndpoint resp) c, ())
+                    return v

--- a/server/src/Postgrid/Utils.hs
+++ b/server/src/Postgrid/Utils.hs
@@ -36,3 +36,4 @@ correctAddressData addrData vsaData = addrData
     , adZipCode = vsadPostalOrZip vsaData
     , adCountry = maybe (adCountry addrData) (Country . unCountryCodeLowercase) (vsadCountry vsaData)
     }
+

--- a/server/src/Postgrid/Utils.hs
+++ b/server/src/Postgrid/Utils.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+module Postgrid.Utils
+    ( addressDataToVerifyStructuredAddressRequest
+    , correctAddressData
+    ) where
+
+import Data.ISO3166_CountryCodes (CountryCode(CA, US))
+import Data.Text as T (null, pack)
+
+import Postgrid.API.Types
+    ( CountryCodeLowercase(..), VerifyStructuredAddressData(..)
+    , VerifyStructuredAddressRequest(..), VerifyStructuredAddressRequestData(..))
+import Models.Fields (regionCode, Country(..), Region(..))
+import Routes.CommonData (AddressData(..))
+
+addressDataToVerifyStructuredAddressRequest :: AddressData -> VerifyStructuredAddressRequest
+addressDataToVerifyStructuredAddressRequest AddressData {..} = VerifyStructuredAddressRequest $
+    VerifyStructuredAddressRequestData
+        { vsardRecipient = if T.null adCompanyName then Nothing else Just adCompanyName
+        , vsardLine1 = adAddressOne
+        , vsardLine2 = if T.null adAddressTwo then Nothing else Just adAddressTwo
+        , vsardCity = adCity
+        , vsardProvinceOrState = let country = fromCountry adCountry in
+            if country == US || country == CA then regionCode adState else T.pack $ show adState
+        , vsardPostalOrZip = adZipCode
+        , vsardCountry = T.pack $ show adCountry
+        }
+
+correctAddressData :: AddressData -> VerifyStructuredAddressData -> AddressData
+correctAddressData addrData vsaData = addrData
+    { adAddressOne = vsadLine1 vsaData
+    , adAddressTwo = ""
+    , adCity = vsadCity vsaData
+    , adState = USState $ vsadProvinceOrState vsaData
+    , adZipCode = vsadPostalOrZip vsaData
+    , adCountry = maybe (adCountry addrData) (Country . unCountryCodeLowercase) (vsadCountry vsaData)
+    }


### PR DESCRIPTION
Shipping address verification is done using [Postgrid](https://www.postgrid.com/address-verification/).

Existing addresses aren't considered verified; the backend will attempt to verify them during the next checkout.
Successful verification status is saved in the DB.

Addresses are verified either during "address edit" in the account settings or during checkout.

To avoid excessive repetitive Postgrid API calls, an additional cache was added to store the latest 100 unique API calls with responses. 