### PR TITLE
Hotfix PostGrid keys provisioning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,6 +122,7 @@ jobs:
       - name: Prepare env
         run: |
           echo "HELCIM_ENV=${{ github.ref == 'refs/heads/master' && 'production' || 'staging' }}" >> $GITHUB_ENV
+          echo "POSTGRID_ENV=${{ github.ref == 'refs/heads/master' && 'production' || 'staging' }}" >> $GITHUB_ENV
           echo "GA_MEASUREMENT_ID='UA-5070189-1'" >> $GITHUB_ENV
 
       - name: Login to GitHub Container Registry
@@ -148,3 +149,4 @@ jobs:
           build-args: |
             HELCIM_ENV
             GA_MEASUREMENT_ID
+            POSTGRID_ENV

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -14,12 +14,13 @@ var RobotsTxtPlugin = require('robotstxt-webpack-plugin');
 
 var isProduction = process.env.NODE_ENV === 'production';
 var isHelcimProduction = process.env.HELCIM_ENV === 'production';
+var isPostgridProduction = process.env.POSTGRID_ENV === 'production';
 
 var helcimUrl = isHelcimProduction ? "https://southern-exposure-seed-exchange.myhelcim.com" : "https://test-southern-exposure-seed-exchange.myhelcim.com";
 
 const GA_MEASUREMENT_ID = process.env.GA_MEASUREMENT_ID;
 // TODO: put actual keys here
-const POSTGRID_API_KEY = process.env.POSTGRID_API_KEY || (isProduction ? "<REPLACE ME WITH THE REAL KEY>" : "live_pk_apy2XeQfGkproRtzeNth6s");
+const POSTGRID_API_KEY = process.env.POSTGRID_API_KEY || (isPostgridProduction ? "<REPLACE ME WITH THE REAL KEY>" : "live_pk_apy2XeQfGkproRtzeNth6s");
 
 module.exports = {
   mode: isProduction ? 'production' : 'development',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - HELCIM_TOKEN_FILE=/run/secrets/helcim_token
       - STRIPE_TOKEN_FILE=/run/secrets/stripe_token
       - COOKIE_SECRET_FILE=/run/secrets/cookie_secret
+      - POSTGRID_API_KEY_FILE=/run/secrets/postgrid_api_key
     secrets:
       - avatax_account_id
       - avatax_company_id
@@ -73,3 +74,5 @@ secrets:
     environment: STRIPE_TOKEN
   cookie_secret:
     environment: COOKIE_SECRET
+  postgrid_api_key:
+    environment: POSTGRID_API_KEY

--- a/server/scripts/entrypoint.sh
+++ b/server/scripts/entrypoint.sh
@@ -36,6 +36,7 @@ file_env "STONE_EDGE_CODE"
 
 file_env "STRIPE_TOKEN"
 file_env "HELCIM_TOKEN"
+file_env "POSTGRID_API_KEY"
 
 file_env "DB_PASS"
 file_env "SMTP_PASS"


### PR DESCRIPTION
1) Pass secret key for the backend as a docker container secret with the
   value taken from the env variable.
2) Pick publick key for the frontend depending on 'POSTGRID_ENV' env
   variable during the frontend build.