### PR TITLE
Make 'city' field optional in PostGrid response

### DIFF
--- a/server/src/Postgrid/API/Types.hs
+++ b/server/src/Postgrid/API/Types.hs
@@ -85,7 +85,7 @@ instance ToJSON AddressVerificationStatus where
 
 -- Data type for the "data" field
 data VerifyStructuredAddressData = VerifyStructuredAddressData
-    { vsadCity            :: Text
+    { vsadCity            :: Maybe Text
     , vsadCountry         :: Maybe CountryCodeLowercase
     , vsadCountryName     :: Maybe Text
     , vsadErrors          :: VerifyStructuredAddressErrors

--- a/server/src/Postgrid/Utils.hs
+++ b/server/src/Postgrid/Utils.hs
@@ -6,6 +6,7 @@ module Postgrid.Utils
     ) where
 
 import Data.ISO3166_CountryCodes (CountryCode(CA, US))
+import Data.Maybe (fromMaybe)
 import Data.Text as T (null, pack)
 
 import Postgrid.API.Types
@@ -31,7 +32,7 @@ correctAddressData :: AddressData -> VerifyStructuredAddressData -> AddressData
 correctAddressData addrData vsaData = addrData
     { adAddressOne = vsadLine1 vsaData
     , adAddressTwo = ""
-    , adCity = vsadCity vsaData
+    , adCity = fromMaybe "" $ vsadCity vsaData
     , adState = USState $ vsadProvinceOrState vsaData
     , adZipCode = vsadPostalOrZip vsaData
     , adCountry = maybe (adCountry addrData) (Country . unCountryCodeLowercase) (vsadCountry vsaData)


### PR DESCRIPTION
Sometimes it is absent and JSON parsing fails.